### PR TITLE
Fix null reference issue in StartupValuesFiller by ensuring inputTemp…

### DIFF
--- a/SW.Bitween.Api/Helpers/StartupValuesFiller.cs
+++ b/SW.Bitween.Api/Helpers/StartupValuesFiller.cs
@@ -12,7 +12,7 @@ public static class StartupValuesFiller
         Partner partner, GlobalAdapterValuesSet[] globals)
     {
         // First fill globals templates
-        var afterGlobals = inputTemplated.Fill(globals ?? []);
+        var afterGlobals = inputTemplated?.Fill(globals ?? []) ?? new Dictionary<string, string>();
         
         // Then fill partner templates using AdapterProperties
         var result = afterGlobals.Fill(partner.AdapterProperties ?? new Dictionary<string, string>(), Partner.TemplateVariableNamePrefix);


### PR DESCRIPTION
…lated is not null before filling globals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-handling in startup configuration processing to prevent potential application crashes during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->