### PR TITLE
adding rabbitmq management url env var

### DIFF
--- a/charts/default/templates/deployment.yaml
+++ b/charts/default/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
             - name: Bitween__BusDefaultQueuePrefetch
               value: "{{ .Values.busDefaultQueuePrefetch }}"
 
+            - name: Bitween__RabbitMqManagementUrl
+              value: {{ .Values.environmentVariables.Bitween__RabbitMqManagementUrl | quote }}
 
             - name: Bitween__StorageProvider
               value: {{ .Values.storageProvider }}

--- a/charts/default/values.yaml
+++ b/charts/default/values.yaml
@@ -34,6 +34,10 @@ ingress:
     # - secretName: chart-example-tls
     #   hosts:
   #     - chart-example.local
+  
+environmentVariables:
+  Bitween__RabbitMqManagementUrl: ""
+  
 secrets:
 
 resources: {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for configuring the RabbitMQ Management URL in deployment settings, allowing operators to specify the management endpoint. Default value is empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->