### PR TITLE
Refactor Subscription constructors to remove WorkGroup parameter and …

### DIFF
--- a/SW.Bitween.Api/Domain/Subscription/Subscription.cs
+++ b/SW.Bitween.Api/Domain/Subscription/Subscription.cs
@@ -14,20 +14,20 @@ namespace SW.Bitween.Domain
         }
 
         //receiving
-        public Subscription(string name, int documentId) : this(WorkGroup.None, name, documentId, SubscriptionType.Receiving)
+        public Subscription(string name, int documentId) : this(name, documentId, SubscriptionType.Receiving)
         {
             Inactive = true;
         }
 
         //aggregation
-        public Subscription(string name, int aggregationFor, int partnerId) : this(WorkGroup.None,name, Document.AggregationDocumentId,
+        public Subscription(string name, int aggregationFor, int partnerId) : this(name, Document.AggregationDocumentId,
             SubscriptionType.Aggregation, partnerId, aggregationFor)
         {
             Inactive = true;
         }
 
         //apiresult or filter
-        public Subscription(string name, int documentId, SubscriptionType type, int partnerId) : this(WorkGroup.None,name, documentId,
+        public Subscription(string name, int documentId, SubscriptionType type, int partnerId) : this(name, documentId,
             type, partnerId, null)
         {
             Inactive = true;
@@ -35,14 +35,14 @@ namespace SW.Bitween.Domain
                 throw new ArgumentException();
         }
 
-        public Subscription(string name, int documentId, SubscriptionType type): this(WorkGroup.None,name, documentId,
-            type)
+        public Subscription(string name, int documentId, SubscriptionType type): this(name, documentId,
+            type, null)
         {
             Inactive = true;
             if (type != SubscriptionType.GatewayApiCall)
                 throw new ArgumentException();
         }
-        private Subscription(WorkGroup workGroup, string name, int documentId, SubscriptionType type, int? partnerId = null,
+        private Subscription(string name, int documentId, SubscriptionType type, int? partnerId = null,
             int? aggregationForId = null, bool temporary = false)
         {
             Inactive = true;
@@ -58,7 +58,7 @@ namespace SW.Bitween.Domain
             ValidatorProperties = new Dictionary<string, string>();
             DocumentFilter = new Dictionary<string, string>();
             Temporary = temporary;
-            WorkGroup = workGroup;
+            WorkGroup = null;
         }
 
         public string Name { get; set; }


### PR DESCRIPTION
…simplify initialization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified Subscription model initialization by removing default WorkGroup assignment, allowing null values instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->