### PR TITLE
feat: add PartnerId to Xchange and inject partner/globals into Scriban templates

### DIFF
--- a/SW.Bitween.Api/Domain/Xchange/Xchange.cs
+++ b/SW.Bitween.Api/Domain/Xchange/Xchange.cs
@@ -41,7 +41,7 @@ namespace SW.Bitween.Domain
         }
 
         public Xchange(Subscription subscription, XchangeFile file, string[] references = null,
-            string correlationId = null, Partner gatewayPartner = null,GlobalAdapterValuesSet[] globalAdapterValuesSets = null) :
+            string correlationId = null, Partner gatewayPartner = null, GlobalAdapterValuesSet[] globalAdapterValuesSets = null) :
             this(subscription.DocumentId, subscription.WorkGroup, file, references, subscription.Type)
         {
             SubscriptionId = subscription.Id;
@@ -49,11 +49,11 @@ namespace SW.Bitween.Domain
             HandlerId = subscription.HandlerId;
             ResponseSubscriptionId = subscription.ResponseSubscriptionId;
             ResponseMessageTypeName = subscription.ResponseMessageTypeName;
-            MapperProperties = subscription.MapperProperties.ToDictionary().Fill(gatewayPartner,globalAdapterValuesSets);
+            PartnerId = gatewayPartner?.Id ?? subscription.PartnerId;
+            MapperProperties = subscription.MapperProperties.ToDictionary().Fill(gatewayPartner, globalAdapterValuesSets);
             HandlerProperties = subscription.HandlerProperties.ToDictionary()
                 .Fill(gatewayPartner, globalAdapterValuesSets);
             CorrelationId = correlationId;
-            
         }
 
         //retry xchange
@@ -61,6 +61,7 @@ namespace SW.Bitween.Domain
             this(xchange.DocumentId, workGroup, file, xchange.References)
         {
             SubscriptionId = xchange.SubscriptionId;
+            PartnerId = xchange.PartnerId;
             MapperId = xchange.MapperId;
             HandlerId = xchange.HandlerId;
             MapperProperties = xchange.MapperProperties;
@@ -75,6 +76,7 @@ namespace SW.Bitween.Domain
             this(xchange.DocumentId, subscription.WorkGroup, file, xchange.References)
         {
             SubscriptionId = xchange.SubscriptionId;
+            PartnerId = xchange.PartnerId ?? subscription.PartnerId;
             MapperId = subscription.MapperId;
             HandlerId = subscription.HandlerId;
             MapperProperties = subscription.MapperProperties;
@@ -85,6 +87,7 @@ namespace SW.Bitween.Domain
         }
 
         public int? SubscriptionId { get; private set; }
+        public int? PartnerId { get; private set; }
         public int DocumentId { get; private set; }
         public string HandlerId { get; private set; }
         public string MapperId { get; private set; }

--- a/SW.Bitween.Api/Resources/Mappers/Preview.cs
+++ b/SW.Bitween.Api/Resources/Mappers/Preview.cs
@@ -39,35 +39,43 @@ public class Preview : ICommandHandler<MapperPreviewRequest, MapperPreviewRespon
     {
         _requestContext.EnsureAccess(AccountRole.Admin, AccountRole.Member);
 
+        var partner = request.PartnerId.HasValue
+            ? await _dbContext.FindAsync<Partner>(request.PartnerId.Value)
+            : null;
+
+        var globalSets = await _dbContext.Set<GlobalAdapterValuesSet>().ToListAsync();
+
         try
         {
             var inputJson = request.InputJson;
-            var jObj = JObject.Parse(inputJson);
-            var enriched = false;
 
-            if (request.PartnerId.HasValue)
+            JObject? jObj = null;
+            if (JToken.Parse(inputJson) is JObject parsedObj)
+                jObj = parsedObj;
+
+            if (jObj != null)
             {
-                var partner = await _dbContext.FindAsync<Partner>(request.PartnerId.Value);
+                var enriched = false;
+
                 if (partner?.AdapterProperties?.Count > 0)
                 {
                     jObj["__partner__"] = JObject.FromObject(partner.AdapterProperties);
                     enriched = true;
                 }
-            }
 
-            // Inject all global adapter values sets as __globals__
-            var globalSets = await _dbContext.Set<GlobalAdapterValuesSet>().ToListAsync();
-            if (globalSets.Any(s => s.Values?.Count > 0))
-            {
-                var globalsObj = new JObject();
-                foreach (var set in globalSets.Where(s => s.Values?.Count > 0))
-                    globalsObj[set.Id] = JObject.FromObject(set.Values);
-                jObj["__globals__"] = globalsObj;
-                enriched = true;
-            }
+                var nonEmptySets = globalSets.Where(s => s.Values?.Count > 0).ToList();
+                if (nonEmptySets.Count > 0)
+                {
+                    var globalsObj = new JObject();
+                    foreach (var set in nonEmptySets)
+                        globalsObj[set.Id] = JObject.FromObject(set.Values);
+                    jObj["__globals__"] = globalsObj;
+                    enriched = true;
+                }
 
-            if (enriched)
-                inputJson = jObj.ToString(Formatting.None);
+                if (enriched)
+                    inputJson = jObj.ToString(Formatting.None);
+            }
 
             var output = ScribanJsonHelper.Render(request.ScribanTemplate, inputJson);
             return new MapperPreviewResponse { OutputJson = output };

--- a/SW.Bitween.Api/Resources/Mappers/Preview.cs
+++ b/SW.Bitween.Api/Resources/Mappers/Preview.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using SW.Bitween.Domain;
 using SW.Bitween.Domain.Accounts;
 using SW.Bitween.NativeAdapters.JsonMapper;
 using SW.PrimitiveTypes;
@@ -10,6 +15,7 @@ public class MapperPreviewRequest
 {
     public string ScribanTemplate { get; set; } = "{}";
     public string InputJson { get; set; } = "{}";
+    public int? PartnerId { get; set; }
 }
 
 public class MapperPreviewResponse
@@ -21,24 +27,54 @@ public class MapperPreviewResponse
 public class Preview : ICommandHandler<MapperPreviewRequest, MapperPreviewResponse>
 {
     private readonly RequestContext _requestContext;
+    private readonly BitweenDbContext _dbContext;
 
-    public Preview(RequestContext requestContext)
+    public Preview(RequestContext requestContext, BitweenDbContext dbContext)
     {
         _requestContext = requestContext;
+        _dbContext = dbContext;
     }
 
-    public Task<MapperPreviewResponse> Handle(MapperPreviewRequest request)
+    public async Task<MapperPreviewResponse> Handle(MapperPreviewRequest request)
     {
         _requestContext.EnsureAccess(AccountRole.Admin, AccountRole.Member);
 
         try
         {
-            var output = ScribanJsonHelper.Render(request.ScribanTemplate, request.InputJson);
-            return Task.FromResult(new MapperPreviewResponse { OutputJson = output });
+            var inputJson = request.InputJson;
+            var jObj = JObject.Parse(inputJson);
+            var enriched = false;
+
+            if (request.PartnerId.HasValue)
+            {
+                var partner = await _dbContext.FindAsync<Partner>(request.PartnerId.Value);
+                if (partner?.AdapterProperties?.Count > 0)
+                {
+                    jObj["__partner__"] = JObject.FromObject(partner.AdapterProperties);
+                    enriched = true;
+                }
+            }
+
+            // Inject all global adapter values sets as __globals__
+            var globalSets = await _dbContext.Set<GlobalAdapterValuesSet>().ToListAsync();
+            if (globalSets.Any(s => s.Values?.Count > 0))
+            {
+                var globalsObj = new JObject();
+                foreach (var set in globalSets.Where(s => s.Values?.Count > 0))
+                    globalsObj[set.Id] = JObject.FromObject(set.Values);
+                jObj["__globals__"] = globalsObj;
+                enriched = true;
+            }
+
+            if (enriched)
+                inputJson = jObj.ToString(Formatting.None);
+
+            var output = ScribanJsonHelper.Render(request.ScribanTemplate, inputJson);
+            return new MapperPreviewResponse { OutputJson = output };
         }
         catch (Exception ex)
         {
-            return Task.FromResult(new MapperPreviewResponse { Error = ex.Message });
+            return new MapperPreviewResponse { Error = ex.Message };
         }
     }
 }

--- a/SW.Bitween.Api/Services/XchangeService.cs
+++ b/SW.Bitween.Api/Services/XchangeService.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using SW.Bus.RabbitMqExtensions;
 
 namespace SW.Bitween;
@@ -131,6 +132,36 @@ public class XchangeService :
     private async Task<XchangeFile> RunMapper(Xchange xchange, XchangeFile xchangeFile)
     {
         if (xchange.MapperId == null) return xchangeFile;
+
+        // Inject __partner__ adapter properties into the input JSON so Scriban templates
+        // can reference them as {{ __partner__?.propkey }}
+        var jObjEnriched = JObject.Parse(xchangeFile.Data);
+        var enriched = false;
+
+        if (xchange.PartnerId.HasValue)
+        {
+            var partner = await _dbContext.FindAsync<Partner>(xchange.PartnerId.Value);
+            if (partner?.AdapterProperties?.Count > 0)
+            {
+                jObjEnriched["__partner__"] = JObject.FromObject(partner.AdapterProperties);
+                enriched = true;
+            }
+        }
+
+        // Inject __globals__ — all global adapter values sets
+        // so templates can use {{ __globals__?.setId?.key }}
+        var globalSets = await _dbContext.Set<GlobalAdapterValuesSet>().ToListAsync();
+        if (globalSets.Any(s => s.Values?.Count > 0))
+        {
+            var globalsObj = new JObject();
+            foreach (var set in globalSets.Where(s => s.Values?.Count > 0))
+                globalsObj[set.Id] = JObject.FromObject(set.Values);
+            jObjEnriched["__globals__"] = globalsObj;
+            enriched = true;
+        }
+
+        if (enriched)
+            xchangeFile = new XchangeFile(jObjEnriched.ToString(Formatting.None), xchangeFile.Filename);
 
         var mapperProperties = xchange.MapperProperties.ToDictionary();
         mapperProperties["xchangeid"] = xchange.Id;

--- a/SW.Bitween.MsSql/Migrations/20260419090137_AddPartnerIdToXchange.Designer.cs
+++ b/SW.Bitween.MsSql/Migrations/20260419090137_AddPartnerIdToXchange.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SW.Bitween;
 
@@ -11,9 +12,11 @@ using SW.Bitween;
 namespace SW.Bitween.MsSql.Migrations
 {
     [DbContext(typeof(BitweenDbContext))]
-    partial class BitweenDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419090137_AddPartnerIdToXchange")]
+    partial class AddPartnerIdToXchange
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SW.Bitween.MsSql/Migrations/20260419090137_AddPartnerIdToXchange.cs
+++ b/SW.Bitween.MsSql/Migrations/20260419090137_AddPartnerIdToXchange.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SW.Bitween.MsSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPartnerIdToXchange : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PartnerId",
+                table: "Xchanges",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PartnerId",
+                table: "Xchanges");
+        }
+    }
+}

--- a/SW.Bitween.MySql/Migrations/20260419090224_AddPartnerIdToXchange.Designer.cs
+++ b/SW.Bitween.MySql/Migrations/20260419090224_AddPartnerIdToXchange.Designer.cs
@@ -3,24 +3,27 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SW.Bitween;
 
 #nullable disable
 
-namespace SW.Bitween.MsSql.Migrations
+namespace SW.Bitween.MySql.Migrations
 {
     [DbContext(typeof(BitweenDbContext))]
-    partial class BitweenDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419090224_AddPartnerIdToXchange")]
+    partial class AddPartnerIdToXchange
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "8.0.26")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
             modelBuilder.Entity("SW.Bitween.Domain.Accounts.Account", b =>
                 {
@@ -28,24 +31,24 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool>("Deleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("Disabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<string>("Email")
                         .HasMaxLength(200)
@@ -53,16 +56,16 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<byte>("EmailProvider")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<byte>("LoginMethods")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Password")
                         .HasMaxLength(500)
@@ -80,8 +83,7 @@ namespace SW.Bitween.MsSql.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("Email")
-                        .IsUnique()
-                        .HasFilter("[Email] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("Accounts", (string)null);
 
@@ -112,10 +114,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte>("LoginMethod")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.HasKey("Id");
 
@@ -130,7 +132,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<bool>("BusEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("BusMessageTypeName")
                         .HasMaxLength(500)
@@ -138,7 +140,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(500)");
 
                     b.Property<bool?>("DisregardsUnfilteredMessages")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("DocumentFormat")
                         .HasColumnType("int");
@@ -153,13 +155,12 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(100)");
 
                     b.Property<string>("PromotedProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
                     b.HasIndex("BusMessageTypeName")
-                        .IsUnique()
-                        .HasFilter("[BusMessageTypeName] IS NOT NULL");
+                        .IsUnique();
 
                     b.HasIndex("Name")
                         .IsUnique();
@@ -182,25 +183,25 @@ namespace SW.Bitween.MsSql.Migrations
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<int>("Code")
                         .HasColumnType("int");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("DocumentId")
                         .HasColumnType("int");
 
                     b.Property<string>("StateAfter")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("StateBefore")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -217,29 +218,29 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<string>("UrlName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.HasKey("Id");
 
@@ -261,16 +262,16 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("ApiGatewayId", "PartnerId", "SubscriptionId");
 
@@ -289,10 +290,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Values")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -305,7 +306,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("HandlerId")
                         .HasMaxLength(200)
@@ -313,27 +314,27 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("HandlerProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Inactive")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("varchar(100)");
 
                     b.Property<bool>("RunOnBadResult")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("RunOnFailedResult")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("RunOnSubscriptions")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("RunOnSuccessfulResult")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("Id");
 
@@ -346,20 +347,20 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<bool>("BadData")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("FileName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("References")
                         .HasMaxLength(1024)
-                        .HasColumnType("nvarchar(1024)");
+                        .HasColumnType("varchar(1024)");
 
                     b.Property<int>("SubscriptionId")
                         .HasColumnType("int");
@@ -377,10 +378,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("AdapterProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -406,16 +407,16 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<DateTime?>("AggregateOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int?>("AggregationForId")
                         .HasColumnType("int");
 
                     b.Property<byte>("AggregationTarget")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<int?>("CategoryId")
                         .HasColumnType("int");
@@ -424,7 +425,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<string>("DocumentFilter")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("DocumentId")
                         .HasColumnType("int");
@@ -435,16 +436,16 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("HandlerProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Inactive")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsRunning")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("LastException")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("MapperId")
                         .HasMaxLength(200)
@@ -452,24 +453,24 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("MapperProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("MatchExpression")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("varchar(100)");
 
                     b.Property<int?>("PartnerId")
                         .HasColumnType("int");
 
                     b.Property<DateTime?>("PausedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime?>("ReceiveOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ReceiverId")
                         .HasMaxLength(200)
@@ -477,7 +478,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("ReceiverProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ResponseMessageTypeName")
                         .HasMaxLength(500)
@@ -488,10 +489,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<bool>("Temporary")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<byte>("Type")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("ValidatorId")
                         .HasMaxLength(200)
@@ -499,7 +500,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("ValidatorProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int?>("WorkGroupId")
                         .HasColumnType("int");
@@ -527,31 +528,30 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Code")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("Code")
-                        .IsUnique()
-                        .HasFilter("[Code] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("SubscriptionCategory");
                 });
@@ -560,22 +560,22 @@ namespace SW.Bitween.MsSql.Migrations
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<int>("Code")
                         .HasColumnType("int");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("StateAfter")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("StateBefore")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("SubscriptionId")
                         .HasColumnType("int");
@@ -595,7 +595,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("BusMessageName")
                         .IsRequired()
@@ -604,10 +604,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(100)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Options")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -622,7 +622,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<string>("CorrelationId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("DocumentId")
                         .HasColumnType("int");
@@ -633,7 +633,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("HandlerProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("InputContentType")
                         .HasMaxLength(200)
@@ -648,7 +648,7 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("InputName")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<int>("InputSize")
                         .HasColumnType("int");
@@ -659,14 +659,14 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("MapperProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int?>("PartnerId")
                         .HasColumnType("int");
 
                     b.Property<string>("References")
                         .HasMaxLength(1024)
-                        .HasColumnType("nvarchar(1024)");
+                        .HasColumnType("varchar(1024)");
 
                     b.Property<string>("ResponseMessageTypeName")
                         .HasMaxLength(500)
@@ -682,7 +682,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<DateTime>("StartedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int?>("SubscriptionId")
                         .HasColumnType("int");
@@ -710,7 +710,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<DateTime>("AggregatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("AggregationXchangeId")
                         .IsRequired()
@@ -733,7 +733,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<DateTime>("DeliveredOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("Id");
 
@@ -748,22 +748,22 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Exception")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("FinishedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("NotifierId")
                         .HasColumnType("int");
 
                     b.Property<string>("NotifierName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Success")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("XchangeId")
                         .HasMaxLength(50)
@@ -788,10 +788,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(2000)");
 
                     b.Property<string>("Properties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("PropertiesRaw")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.HasKey("Id");
 
@@ -808,13 +808,13 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<string>("Exception")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("FinishedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool>("OutputBad")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("OutputContentType")
                         .HasMaxLength(200)
@@ -828,13 +828,13 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("OutputName")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<int>("OutputSize")
                         .HasColumnType("int");
 
                     b.Property<bool>("ResponseBad")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("ResponseContentType")
                         .HasMaxLength(200)
@@ -848,16 +848,16 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("ResponseName")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<int>("ResponseSize")
                         .HasColumnType("int");
 
                     b.Property<string>("ResponseXchangeId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Success")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("Id");
 
@@ -867,7 +867,7 @@ namespace SW.Bitween.MsSql.Migrations
             modelBuilder.Entity("SW.Bitween.RunFlagUpdater+RunningResult", b =>
                 {
                     b.Property<bool>("IsRunning")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.ToTable((string)null);
 
@@ -932,7 +932,7 @@ namespace SW.Bitween.MsSql.Migrations
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType("int");
 
-                            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b1.Property<int>("Id"));
+                            MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b1.Property<int>("Id"));
 
                             b1.Property<string>("Key")
                                 .IsRequired()
@@ -943,7 +943,7 @@ namespace SW.Bitween.MsSql.Migrations
                             b1.Property<string>("Name")
                                 .IsRequired()
                                 .HasMaxLength(500)
-                                .HasColumnType("nvarchar(500)");
+                                .HasColumnType("varchar(500)");
 
                             b1.HasKey("PartnerId", "Id");
 
@@ -1010,16 +1010,16 @@ namespace SW.Bitween.MsSql.Migrations
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType("int");
 
-                            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b1.Property<int>("Id"));
+                            MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b1.Property<int>("Id"));
 
                             b1.Property<bool>("Backwards")
-                                .HasColumnType("bit");
+                                .HasColumnType("tinyint(1)");
 
                             b1.Property<long>("On")
                                 .HasColumnType("bigint");
 
                             b1.Property<byte>("Recurrence")
-                                .HasColumnType("tinyint");
+                                .HasColumnType("tinyint unsigned");
 
                             b1.HasKey("SubscriptionId", "Id");
 

--- a/SW.Bitween.MySql/Migrations/20260419090224_AddPartnerIdToXchange.cs
+++ b/SW.Bitween.MySql/Migrations/20260419090224_AddPartnerIdToXchange.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SW.Bitween.MySql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPartnerIdToXchange : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "PartnerId",
+                table: "Xchanges",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PartnerId",
+                table: "Xchanges");
+        }
+    }
+}

--- a/SW.Bitween.MySql/Migrations/BitweenDbContextModelSnapshot.cs
+++ b/SW.Bitween.MySql/Migrations/BitweenDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace SW.Bitween.MySql.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "8.0.23")
+                .HasAnnotation("ProductVersion", "8.0.26")
                 .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
             MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
@@ -657,6 +657,9 @@ namespace SW.Bitween.MySql.Migrations
 
                     b.Property<string>("MapperProperties")
                         .HasColumnType("longtext");
+
+                    b.Property<int?>("PartnerId")
+                        .HasColumnType("int");
 
                     b.Property<string>("References")
                         .HasMaxLength(1024)

--- a/SW.Bitween.PgSql/Migrations/20260419092109_AddPartnerIdToXchange.Designer.cs
+++ b/SW.Bitween.PgSql/Migrations/20260419092109_AddPartnerIdToXchange.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SW.Bitween.Model;
@@ -13,9 +14,11 @@ using SW.Bitween.PgSql;
 namespace SW.Bitween.PgSql.Migrations
 {
     [DbContext(typeof(BitweenDbContext))]
-    partial class BitweenDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419092109_AddPartnerIdToXchange")]
+    partial class AddPartnerIdToXchange
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SW.Bitween.PgSql/Migrations/20260419092109_AddPartnerIdToXchange.cs
+++ b/SW.Bitween.PgSql/Migrations/20260419092109_AddPartnerIdToXchange.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SW.Bitween.PgSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPartnerIdToXchange : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "partner_id",
+                schema: "infolink",
+                table: "xchange",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "partner_id",
+                schema: "infolink",
+                table: "xchange");
+        }
+    }
+}

--- a/SW.Bitween.PgSql/Migrations/BitweenDbContextModelSnapshot.cs
+++ b/SW.Bitween.PgSql/Migrations/BitweenDbContextModelSnapshot.cs
@@ -20,7 +20,7 @@ namespace SW.Bitween.PgSql.Migrations
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("infolink")
-                .HasAnnotation("ProductVersion", "8.0.23")
+                .HasAnnotation("ProductVersion", "8.0.26")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);


### PR DESCRIPTION

- Add PartnerId property to Xchange domain entity, propagated from subscription or gateway partner through all constructors including retries
- Add AddPartnerIdToXchange migration for MsSql, MySql, and PgSql
- Inject __partner__ adapter properties and __globals__ (all GlobalAdapterValuesSets) into xchange input JSON before Scriban template rendering in XchangeService
- Update mapper preview endpoint (Preview.cs) to accept optional PartnerId, injecting the same __partner__ and __globals__ context for accurate live preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Exchanges can now be linked to specific partners
* Mapper preview and rendering operations now automatically enrich template data with partner adapter properties and global adapter values
* Partner-specific configuration is now accessible within templates during data transformation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->