### PR TITLE
fix: update property names to camelCase in BuildScriptObject method

### DIFF
--- a/SW.Bitween.Api/Services/XchangeService.cs
+++ b/SW.Bitween.Api/Services/XchangeService.cs
@@ -410,14 +410,6 @@ public class XchangeService :
         }
     }
 
-    // Task IConsume<ApiXchangeCreatedEvent>.Process(ApiXchangeCreatedEvent message) => Process(message);
-    //
-    // Task IConsume<AggregateXchangeCreatedEvent>.Process(AggregateXchangeCreatedEvent message) => Process(message);
-    //
-    // Task IConsume<InternalXchangeCreatedEvent>.Process(InternalXchangeCreatedEvent message) => Process(message);
-    //
-    // Task IConsume<ReceivingXchangeCreatedEvent>.Process(ReceivingXchangeCreatedEvent message) => Process(message);
-
 
     private async Task ProcessResult(XchangeMessage message)
     {

--- a/SW.Bitween.NativeAdapters/JsonMapper/ScribanJsonHelper.cs
+++ b/SW.Bitween.NativeAdapters/JsonMapper/ScribanJsonHelper.cs
@@ -91,7 +91,10 @@ public static class ScribanJsonHelper
         var so = new ScriptObject();
         foreach (var prop in obj.Properties())
         {
-            so[prop.Name] = ToScribanValue(prop.Value);
+            var key = prop.Name.Length > 0
+                ? char.ToLowerInvariant(prop.Name[0]) + prop.Name[1..]
+                : prop.Name;
+            so[key] = ToScribanValue(prop.Value);
         }
         return so;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete code comments.

* **Refactor**
  * JSON property keys are now automatically converted to camelCase format in template processing (e.g., "Buyer" → "buyer").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->