### PR TITLE
fix: preserve original JSON key casing in Scriban template mapping

### DIFF
--- a/SW.Bitween.NativeAdapters/JsonMapper/ScribanJsonHelper.cs
+++ b/SW.Bitween.NativeAdapters/JsonMapper/ScribanJsonHelper.cs
@@ -92,10 +92,20 @@ public static class ScribanJsonHelper
         var so = new ScriptObject();
         foreach (var prop in obj.Properties())
         {
-            var key = prop.Name.Length > 0
-                ? char.ToLowerInvariant(prop.Name[0]) + prop.Name[1..]
-                : prop.Name;
-            so[key] = ToScribanValue(prop.Value);
+            var value = ToScribanValue(prop.Value);
+
+            // Always store with the original key so templates that reference the
+            // exact JSON casing (e.g. partner props like "CustomerId") work correctly.
+            so[prop.Name] = value;
+
+            // Also register a first-char-lowercased alias so that templates written
+            // before this fix (which relied on camelCase normalisation) continue to work.
+            if (prop.Name.Length > 0 && char.IsUpper(prop.Name[0]))
+            {
+                var lcKey = char.ToLowerInvariant(prop.Name[0]) + prop.Name[1..];
+                if (!so.ContainsKey(lcKey))
+                    so[lcKey] = value;
+            }
         }
         return so;
     }

--- a/SW.Bitween.Web/Startup.cs
+++ b/SW.Bitween.Web/Startup.cs
@@ -78,6 +78,7 @@ namespace SW.Bitween.Web
 
             var serializer = new JsonSerializer();
             serializer.Converters.Add(new PropertyMatchSpecificationJsonConverter());
+            serializer.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
             serializer.ContractResolver = new CamelCasePropertyNamesContractResolver
             {
                 NamingStrategy = new CamelCaseNamingStrategy


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * JSON property casing in templates now preserves original key casing with automatic lowercase-first-character fallback support
  * Enum values in JSON serialization are now represented as strings instead of numeric values

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/simplify9/Bitween-api/pull/159)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->