### PR TITLE
fix: handle RabbitMQ unavailability gracefully in WorkGroups search

### DIFF
--- a/SW.Bitween.Api/Resources/WorkGroups/Search.cs
+++ b/SW.Bitween.Api/Resources/WorkGroups/Search.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using SW.Bitween.Domain;
 using SW.Bitween.Model;
 using SW.Bus.RabbitMqExtensions;
@@ -8,7 +10,10 @@ using SW.PrimitiveTypes;
 
 namespace SW.Bitween.Resources.WorkGroups;
 
-public class Search(IInfolinkCache infolinkCache,IConsumerReader consumerReader)
+public class Search(
+    IInfolinkCache infolinkCache,
+    IConsumerReader consumerReader,
+    ILogger<Search> logger)
     : IQueryHandler<SearchWorkGroupModel, object>
 {
 
@@ -18,7 +23,16 @@ public class Search(IInfolinkCache infolinkCache,IConsumerReader consumerReader)
         request.Offset ??= 0;
         
         var workGroups = await infolinkCache.ListWorkGroupsAsync();
-        var consumerCounts = await consumerReader.GetConsumerCount<XchangeService>();
+        var consumerCounts = Array.Empty<ConsumerCount>();
+
+        try
+        {
+            consumerCounts = await consumerReader.GetConsumerCount<XchangeService>();
+        }
+        catch (Exception ex) when (ex is TaskCanceledException or TimeoutException or System.Net.Http.HttpRequestException)
+        {
+            logger.LogWarning(ex, "Unable to load RabbitMQ consumer metrics for work groups.");
+        }
 
         var data= workGroups
             .OrderByDescending(i => i.Id)


### PR DESCRIPTION
Falls back to empty consumer counts instead of crashing the page when RabbitMQ is unreachable.