### PR TITLE
fix: return generic "invalid username or password" on login failure

### DIFF
--- a/SW.Bitween.Api/Resources/Accounts/Login.cs
+++ b/SW.Bitween.Api/Resources/Accounts/Login.cs
@@ -93,8 +93,7 @@ namespace SW.Bitween.Resources.Accounts
                     throw new SWException("Your Microsoft account is not registered in the system. Please contact your administrator to be added.");
                 }
 
-                var identifier = request.Username ?? "unknown";
-                throw new SWValidationException(identifier, identifier);
+                throw new SWException("Invalid username or password.");
             }
 
             if (account.Disabled)
@@ -114,7 +113,7 @@ namespace SW.Bitween.Resources.Accounts
             {
                 if (request.Password == null ||
                     !SecurePasswordHasher.Verify(request.Password, account.Password))
-                    throw new SWException("Invalid password.");
+                    throw new SWException("Invalid username or password.");
             }
 
             var newRefreshToken = CreateRefreshToken(account, LoginMethod.EmailAndPassword);


### PR DESCRIPTION
Replace SWValidationException (which leaked the submitted email back as the error message) and the "Invalid password." message with a single generic "Invalid username or password." for both unknown-user and wrong-password cases — avoids revealing whether an account exists.