### PR TITLE
refactor: move Rebex license key into BitweenOptions

### DIFF
--- a/SW.Bitween.Api/Services/BitweenOptions.cs
+++ b/SW.Bitween.Api/Services/BitweenOptions.cs
@@ -68,6 +68,11 @@ namespace SW.Bitween
         public string RabbitMqManagementPassword { get; set; }
 
         /// <summary>
+        /// License key for the Rebex POP3 library. When not set, the native Rebex POP3 receiver adapter is not registered.
+        /// </summary>
+        public string RebexLicenseKey { get; set; }
+
+        /// <summary>
         /// Allowed CORS origins for credential-bearing requests (cookies).
         /// When set, enables AllowCredentials() on the CORS policy.
         /// Example: ["https://localhost:3000", "https://slim-dev.starlinks-me.com"]

--- a/SW.Bitween.NativeAdapters/RebexPop3Receiver/NativeRebexPop3Receiver.cs
+++ b/SW.Bitween.NativeAdapters/RebexPop3Receiver/NativeRebexPop3Receiver.cs
@@ -6,7 +6,7 @@ namespace SW.Bitween.NativeAdapters.RebexPop3Receiver;
 
 public class NativeRebexPop3Receiver : INativeInfolinkReceiver
 {
-    public const string LicenseKeyEnvironmentVariable = "REBEX_LICENSE_KEY";
+    private readonly string? _licenseKey;
 
     private RebexPop3ReceiverInput _options = new();
     private Pop3 _pop3 = new();
@@ -16,9 +16,14 @@ public class NativeRebexPop3Receiver : INativeInfolinkReceiver
     internal int Port { get; set; } = 995;
     internal bool UseSsl { get; set; } = true;
 
+    public NativeRebexPop3Receiver(string? licenseKey = null)
+    {
+        _licenseKey = licenseKey;
+    }
+
     public async Task Initialize()
     {
-        Rebex.Licensing.Key = Environment.GetEnvironmentVariable(LicenseKeyEnvironmentVariable);
+        Rebex.Licensing.Key = _licenseKey;
         _pop3 = new Pop3();
         var sslMode = UseSsl ? SslMode.Implicit : SslMode.None;
         await _pop3.ConnectAsync(_options.Host, Port, sslMode);

--- a/SW.Bitween.NativeAdapters/ServiceCollectionExtensions.cs
+++ b/SW.Bitween.NativeAdapters/ServiceCollectionExtensions.cs
@@ -7,7 +7,7 @@ namespace SW.Bitween.NativeAdapters;
 
 public static class ServiceCollectionExtensions
 {
-    public static void AddNativeAdapters(this IServiceCollection serviceCollection)
+    public static void AddNativeAdapters(this IServiceCollection serviceCollection, string? rebexLicenseKey = null)
     {
         serviceCollection.ConfigureHttpClientDefaults(builder =>
         {
@@ -36,10 +36,10 @@ public static class ServiceCollectionExtensions
         serviceCollection.AddScoped<INativeInfolinkReceiver, NativePop3Receiver>();
         serviceCollection.AddScoped<INativeAdapter, NativePop3Receiver>();
 
-        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(NativeRebexPop3Receiver.LicenseKeyEnvironmentVariable)))
+        if (!string.IsNullOrEmpty(rebexLicenseKey))
         {
-            serviceCollection.AddScoped<INativeInfolinkReceiver, NativeRebexPop3Receiver>();
-            serviceCollection.AddScoped<INativeAdapter, NativeRebexPop3Receiver>();
+            serviceCollection.AddScoped<INativeInfolinkReceiver>(_ => new NativeRebexPop3Receiver(rebexLicenseKey));
+            serviceCollection.AddScoped<INativeAdapter>(_ => new NativeRebexPop3Receiver(rebexLicenseKey));
         }
     }
 }

--- a/SW.Bitween.UnitTests/NativeRebexPop3ReceiverTests.cs
+++ b/SW.Bitween.UnitTests/NativeRebexPop3ReceiverTests.cs
@@ -3,24 +3,31 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SW.Bitween.NativeAdapters.RebexPop3Receiver;
 
 namespace SW.Bitween.UnitTests;
 
 /// <summary>
-/// Requires a real Rebex license via the REBEX_LICENSE_KEY environment variable.
+/// Requires a real Rebex license via the Bitween:RebexLicenseKey configuration value
+/// (settable through the Bitween__RebexLicenseKey environment variable).
 /// Tests report Inconclusive (not Failed) when it's not set, so CI/dev machines
 /// without a license don't fail the build.
 /// </summary>
 [TestClass]
 public class NativeRebexPop3ReceiverTests
 {
+    private static readonly string LicenseKey = new ConfigurationBuilder()
+        .AddEnvironmentVariables()
+        .Build()
+        .GetSection(BitweenOptions.ConfigurationSection)[nameof(BitweenOptions.RebexLicenseKey)];
+
     [TestInitialize]
     public void SkipIfNoLicense()
     {
-        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(NativeRebexPop3Receiver.LicenseKeyEnvironmentVariable)))
-            Assert.Inconclusive($"{NativeRebexPop3Receiver.LicenseKeyEnvironmentVariable} is not set.");
+        if (string.IsNullOrEmpty(LicenseKey))
+            Assert.Inconclusive($"{BitweenOptions.ConfigurationSection}:{nameof(BitweenOptions.RebexLicenseKey)} is not set.");
     }
 
     private static Dictionary<string, string> Settings(string encoding = "utf8", int batchSize = 50) => new()
@@ -34,7 +41,7 @@ public class NativeRebexPop3ReceiverTests
 
     private static NativeRebexPop3Receiver CreateReceiver(FakePop3Server server, string encoding = "utf8", int batchSize = 50)
     {
-        var receiver = new NativeRebexPop3Receiver { Port = server.Port, UseSsl = false };
+        var receiver = new NativeRebexPop3Receiver(LicenseKey) { Port = server.Port, UseSsl = false };
         receiver.InitializeStartupValues(Settings(encoding, batchSize));
         return receiver;
     }

--- a/SW.Bitween.Web/Startup.cs
+++ b/SW.Bitween.Web/Startup.cs
@@ -289,7 +289,7 @@ namespace SW.Bitween.Web
                     });
             });
 
-            services.AddNativeAdapters();
+            services.AddNativeAdapters(bitweenOptions.RebexLicenseKey);
 
             // services.AddScoped<INativeInfolinkHandler, NativeUpdatePartnerPropsHandler>();
             // services.AddScoped<INativeAdapter, NativeUpdatePartnerPropsHandler>();


### PR DESCRIPTION
Replaces the ad-hoc REBEX_LICENSE_KEY environment variable read inside NativeRebexPop3Receiver with a RebexLicenseKey option on BitweenOptions, bound from config like every other setting (Bitween__RebexLicenseKey). The key is threaded through AddNativeAdapters instead of the adapter reaching into Environment directly.