### PR TITLE
feat: add native AzureBlob upload handler and receiver

### DIFF
--- a/SW.Bitween.NativeAdapters/AzureBlobReceiver/AzureBlobReceiverInput.cs
+++ b/SW.Bitween.NativeAdapters/AzureBlobReceiver/AzureBlobReceiverInput.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace SW.Bitween.NativeAdapters.AzureBlobReceiver;
+
+public class AzureBlobReceiverInput
+{
+    [Required]
+    [Secure]
+    public string ConnectionString { get; set; } = string.Empty;
+
+    [Required]
+    public string ContainerName { get; set; } = string.Empty;
+
+    public string? FolderName { get; set; }
+
+    [DefaultValue(50)]
+    public int BatchSize { get; set; } = 50;
+
+    [DefaultValue("utf8")]
+    public string ResponseEncoding { get; set; } = "utf8";
+
+    public string? DeleteMovesFileTo { get; set; }
+}

--- a/SW.Bitween.NativeAdapters/AzureBlobReceiver/NativeAzureBlobReceiver.cs
+++ b/SW.Bitween.NativeAdapters/AzureBlobReceiver/NativeAzureBlobReceiver.cs
@@ -25,7 +25,11 @@ public class NativeAzureBlobReceiver : INativeInfolinkReceiver
     {
         var blobNames = new List<string>();
 
-        await foreach (var blob in _container.GetBlobsAsync(BlobTraits.None, BlobStates.None, _options.FolderName))
+        // Trailing slash keeps the prefix scoped to the folder itself, so a sibling
+        // like "incoming-archive/x.txt" doesn't match a FolderName of "incoming".
+        var prefix = string.IsNullOrEmpty(_options.FolderName) ? _options.FolderName : _options.FolderName + "/";
+
+        await foreach (var blob in _container.GetBlobsAsync(BlobTraits.None, BlobStates.None, prefix))
         {
             blobNames.Add(blob.Name);
             if (blobNames.Count >= _options.BatchSize)
@@ -55,6 +59,13 @@ public class NativeAzureBlobReceiver : INativeInfolinkReceiver
 
     public async Task DeleteFile(string fileId)
     {
+        var sourceBlob = _container.GetBlobClient(fileId);
+
+        // Retry-safe: if a prior attempt already moved/deleted this file, there's
+        // nothing left to do — treat it as already completed, not an error.
+        if (!await sourceBlob.ExistsAsync())
+            return;
+
         if (!string.IsNullOrWhiteSpace(_options.DeleteMovesFileTo))
         {
             // Preserve the path relative to FolderName so files with the same name in
@@ -66,12 +77,11 @@ public class NativeAzureBlobReceiver : INativeInfolinkReceiver
 
             // Server-side copy: Azure moves the blob internally, so no bytes are
             // downloaded or re-uploaded through this process.
-            var sourceBlob = _container.GetBlobClient(fileId);
             var targetBlob = _container.GetBlobClient(targetName);
             await targetBlob.SyncCopyFromUriAsync(sourceBlob.Uri);
         }
 
-        await _container.GetBlobClient(fileId).DeleteAsync();
+        await sourceBlob.DeleteAsync();
     }
 
     public string Name => "NativeAzureBlobReceiver";

--- a/SW.Bitween.NativeAdapters/AzureBlobReceiver/NativeAzureBlobReceiver.cs
+++ b/SW.Bitween.NativeAdapters/AzureBlobReceiver/NativeAzureBlobReceiver.cs
@@ -1,0 +1,85 @@
+using System.Text;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using SW.PrimitiveTypes;
+
+namespace SW.Bitween.NativeAdapters.AzureBlobReceiver;
+
+public class NativeAzureBlobReceiver : INativeInfolinkReceiver
+{
+    private AzureBlobReceiverInput _options = new();
+    private BlobContainerClient _container = null!;
+
+    public Task Initialize()
+    {
+        _container = new BlobContainerClient(_options.ConnectionString.Trim(), _options.ContainerName.Trim());
+        return Task.CompletedTask;
+    }
+
+    public Task Finalize()
+    {
+        return Task.CompletedTask;
+    }
+
+    public async Task<IEnumerable<string>> ListFiles()
+    {
+        var blobNames = new List<string>();
+
+        await foreach (var blob in _container.GetBlobsAsync(BlobTraits.None, BlobStates.None, _options.FolderName))
+        {
+            blobNames.Add(blob.Name);
+            if (blobNames.Count >= _options.BatchSize)
+                break;
+        }
+
+        return blobNames;
+    }
+
+    public async Task<XchangeFile> GetFile(string fileId)
+    {
+        var blobClient = _container.GetBlobClient(fileId);
+        var download = await blobClient.DownloadAsync();
+
+        using var memoryStream = new MemoryStream();
+        await download.Value.Content.CopyToAsync(memoryStream);
+        var bytes = memoryStream.ToArray();
+
+        return (_options.ResponseEncoding ?? "utf8").ToLower() switch
+        {
+            "base64" => new XchangeFile(Convert.ToBase64String(bytes), fileId),
+            "utf8" => new XchangeFile(Encoding.UTF8.GetString(bytes), fileId),
+            _ => throw new ArgumentException(
+                $"Unknown {nameof(AzureBlobReceiverInput.ResponseEncoding)} '{_options.ResponseEncoding}'")
+        };
+    }
+
+    public async Task DeleteFile(string fileId)
+    {
+        if (!string.IsNullOrWhiteSpace(_options.DeleteMovesFileTo))
+        {
+            // Preserve the path relative to FolderName so files with the same name in
+            // different subdirectories don't collide at the destination.
+            var relativePath = !string.IsNullOrEmpty(_options.FolderName) && fileId.StartsWith(_options.FolderName + "/")
+                ? fileId[(_options.FolderName.Length + 1)..]
+                : fileId;
+            var targetName = $"{_options.DeleteMovesFileTo}/{relativePath}";
+
+            // Server-side copy: Azure moves the blob internally, so no bytes are
+            // downloaded or re-uploaded through this process.
+            var sourceBlob = _container.GetBlobClient(fileId);
+            var targetBlob = _container.GetBlobClient(targetName);
+            await targetBlob.SyncCopyFromUriAsync(sourceBlob.Uri);
+        }
+
+        await _container.GetBlobClient(fileId).DeleteAsync();
+    }
+
+    public string Name => "NativeAzureBlobReceiver";
+
+    public void InitializeStartupValues(IDictionary<string, string> settings)
+    {
+        _options = settings.ConvertTo<AzureBlobReceiverInput>();
+    }
+
+    public Type StartupValuesType => typeof(AzureBlobReceiverInput);
+}

--- a/SW.Bitween.NativeAdapters/AzureBlobUploadHandler/AzureBlobUploadHandlerInput.cs
+++ b/SW.Bitween.NativeAdapters/AzureBlobUploadHandler/AzureBlobUploadHandlerInput.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace SW.Bitween.NativeAdapters.AzureBlobUploadHandler;
+
+public class AzureBlobUploadHandlerInput
+{
+    [Required]
+    [Secure]
+    public string ConnectionString { get; set; } = string.Empty;
+
+    [Required]
+    public string ContainerName { get; set; } = string.Empty;
+
+    public string? FileName { get; set; }
+
+    public string? FileExtension { get; set; }
+}

--- a/SW.Bitween.NativeAdapters/AzureBlobUploadHandler/NativeAzureBlobUploadHandler.cs
+++ b/SW.Bitween.NativeAdapters/AzureBlobUploadHandler/NativeAzureBlobUploadHandler.cs
@@ -1,0 +1,38 @@
+using System.Text;
+using Azure.Storage.Blobs;
+using SW.PrimitiveTypes;
+
+namespace SW.Bitween.NativeAdapters.AzureBlobUploadHandler;
+
+public class NativeAzureBlobUploadHandler : INativeInfolinkHandler
+{
+    private AzureBlobUploadHandlerInput _options = new();
+
+    public async Task<XchangeFile> Handle(XchangeFile xchangeFile)
+    {
+        var container = new BlobContainerClient(_options.ConnectionString.Trim(), _options.ContainerName.Trim());
+
+        var blobName = _options.FileName;
+        if (string.IsNullOrWhiteSpace(blobName))
+        {
+            var extension = _options.FileExtension?.TrimStart('.');
+            var name = $"{DateTime.UtcNow:yyyyMMddHHmmss}_{Guid.NewGuid():N}";
+            blobName = string.IsNullOrEmpty(extension) ? name : $"{name}.{extension}";
+        }
+
+        var blobClient = container.GetBlobClient(blobName);
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(xchangeFile.Data));
+        await blobClient.UploadAsync(stream, overwrite: true);
+
+        return new XchangeFile(blobName, xchangeFile.Filename);
+    }
+
+    public string Name => "NativeAzureBlobUploadHandler";
+
+    public void InitializeStartupValues(IDictionary<string, string> settings)
+    {
+        _options = settings.ConvertTo<AzureBlobUploadHandlerInput>();
+    }
+
+    public Type StartupValuesType => typeof(AzureBlobUploadHandlerInput);
+}

--- a/SW.Bitween.NativeAdapters/SW.Bitween.NativeAdapters.csproj
+++ b/SW.Bitween.NativeAdapters/SW.Bitween.NativeAdapters.csproj
@@ -14,6 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
       <PackageReference Include="DotLiquid" Version="2.2.692" />
       <PackageReference Include="MailKit" Version="4.17.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/SW.Bitween.NativeAdapters/ServiceCollectionExtensions.cs
+++ b/SW.Bitween.NativeAdapters/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
+using SW.Bitween.NativeAdapters.AzureBlobReceiver;
+using SW.Bitween.NativeAdapters.AzureBlobUploadHandler;
 using SW.Bitween.NativeAdapters.HttpReceiver;
 using SW.Bitween.NativeAdapters.Pop3Receiver;
 using SW.Bitween.NativeAdapters.RebexFtpReceiver;
@@ -45,6 +47,12 @@ public static class ServiceCollectionExtensions
 
         serviceCollection.AddScoped<INativeInfolinkReceiver, NativeS3Receiver>();
         serviceCollection.AddScoped<INativeAdapter, NativeS3Receiver>();
+
+        serviceCollection.AddScoped<INativeInfolinkHandler, NativeAzureBlobUploadHandler>();
+        serviceCollection.AddScoped<INativeAdapter, NativeAzureBlobUploadHandler>();
+
+        serviceCollection.AddScoped<INativeInfolinkReceiver, NativeAzureBlobReceiver>();
+        serviceCollection.AddScoped<INativeAdapter, NativeAzureBlobReceiver>();
 
         if (!string.IsNullOrEmpty(rebexLicenseKey))
         {


### PR DESCRIPTION
Port the serverless AzureBlob handler and receiver into in-process native adapters, with collision-safe filenames, batch/folder limits, and a server-side copy for move-on-delete.