### PR TITLE
fix: return retry policy fields from subscription Get/Search

### DIFF
--- a/SW.Bitween.Api/Resources/Subscriptions/Get.cs
+++ b/SW.Bitween.Api/Resources/Subscriptions/Get.cs
@@ -62,6 +62,8 @@ namespace SW.Bitween.Resources.Subscriptions
                     CategoryCode = subscriber.Category?.Code,
                     CategoryId = subscriber.CategoryId,
                     WorkGroupId = subscriber.WorkGroupId,
+                    RetryPolicyId = subscriber.RetryPolicyId,
+                    CustomRetryPolicy = subscriber.CustomRetryPolicy,
                     Schedules = subscriber.Schedules.Select(s => new ScheduleView
                     {
                         Backwards = s.Backwards,

--- a/SW.Bitween.Api/Resources/Subscriptions/Search.cs
+++ b/SW.Bitween.Api/Resources/Subscriptions/Search.cs
@@ -62,7 +62,9 @@ namespace SW.Bitween.Resources.Subscriptions
                     WorkGroupId =  subscriber.WorkGroupId,
                     CategoryDescription = subscriber.Category.Description,
                     CategoryCode = subscriber.Category.Code,
-                    
+                    RetryPolicyId = subscriber.RetryPolicyId,
+                    CustomRetryPolicy = subscriber.CustomRetryPolicy,
+
                 };
 
             query = query.AsNoTracking().AsQueryable();


### PR DESCRIPTION
Get.cs and Search.cs never mapped RetryPolicyId/CustomRetryPolicy onto the response, so a saved retry policy vanished on refresh even though the write path was correct.