### PR TITLE
Upgraded to

### DIFF
--- a/SW.Bitween.Api/SW.Bitween.Api.csproj
+++ b/SW.Bitween.Api/SW.Bitween.Api.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.3.1" />
     <PackageReference Include="SimplyWorks.Bus.RabbitMqExtensions" Version="8.1.11" />
     <PackageReference Include="SimplyWorks.EfCoreExtensions" Version="8.1.2" />
-    <PackageReference Include="SimplyWorks.Scheduler.Sdk" Version="8.1.3" />
+    <PackageReference Include="SimplyWorks.Scheduler.Sdk" Version="8.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SW.Bitween.MsSql/SW.Bitween.MsSql.csproj
+++ b/SW.Bitween.MsSql/SW.Bitween.MsSql.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SW.Bitween.Api\SW.Bitween.Api.csproj" />
-    <PackageReference Include="SimplyWorks.Scheduler.SqlServer" Version="8.1.3" />
+    <PackageReference Include="SimplyWorks.Scheduler.SqlServer" Version="8.1.7" />
   </ItemGroup>
 
 

--- a/SW.Bitween.MySql/SW.Bitween.MySql.csproj
+++ b/SW.Bitween.MySql/SW.Bitween.MySql.csproj
@@ -15,7 +15,7 @@
   
   <ItemGroup>
     <ProjectReference Include="..\SW.Bitween.Api\SW.Bitween.Api.csproj" />
-    <PackageReference Include="SimplyWorks.Scheduler.MySql" Version="8.1.3" />
+    <PackageReference Include="SimplyWorks.Scheduler.MySql" Version="8.1.7" />
   </ItemGroup>
   
 

--- a/SW.Bitween.PgSql/SW.Bitween.PgSql.csproj
+++ b/SW.Bitween.PgSql/SW.Bitween.PgSql.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\SW.Bitween.Api\SW.Bitween.Api.csproj" />
-    <PackageReference Include="SimplyWorks.Scheduler.PgSql" Version="8.1.3" />
+    <PackageReference Include="SimplyWorks.Scheduler.PgSql" Version="8.1.7" />
   </ItemGroup>
 
 

--- a/SW.Bitween.Web/SW.Bitween.Web.csproj
+++ b/SW.Bitween.Web/SW.Bitween.Web.csproj
@@ -36,7 +36,7 @@
     <ProjectReference Include="..\SW.Bitween.MySql\SW.Bitween.MySql.csproj" />
     <ProjectReference Include="..\SW.Bitween.PgSql\SW.Bitween.PgSql.csproj" />
     <ProjectReference Include="..\SW.Bitween.NativeAdapters\SW.Bitween.NativeAdapters.csproj" />
-    <PackageReference Include="SimplyWorks.Scheduler.EfCore" Version="8.1.3" />
+    <PackageReference Include="SimplyWorks.Scheduler.EfCore" Version="8.1.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
SimplyWorks.Scheduler.* 8.1.7, which pins triggers to UTC explicitly, and matched Schedule.Next() to agree