### PR TITLE
Enforce MaxAttemptsTotal across messages instead of per message

### DIFF
--- a/SW.Bitween.Api/Data/BitweenDbContext.cs
+++ b/SW.Bitween.Api/Data/BitweenDbContext.cs
@@ -236,8 +236,15 @@ namespace SW.Bitween
                 b.HasKey(p => p.Id);
                 b.Property(p => p.Id).IsUnicode(false).HasMaxLength(50);
                 b.Property(p => p.On);
-                b.Property(p => p.GroupAttemptCounts).StoreAsJson();
                 b.HasIndex(p => p.On);
+            });
+
+            modelBuilder.Entity<RetryGroupUsage>(b =>
+            {
+                b.ToTable("RetryGroupUsages");
+                b.HasKey(p => new { p.SubscriptionId, p.GroupId });
+                b.Property(p => p.AttemptsUsed);
+                b.Property(p => p.LastAttemptOn);
             });
 
             modelBuilder.Entity<Xchange>(b =>
@@ -252,7 +259,6 @@ namespace SW.Bitween
                 b.Property(p => p.HandlerId).HasMaxLength(200).IsUnicode(false);
                 b.Property(p => p.HandlerProperties).StoreAsJson();
                 b.Property(p => p.MapperProperties).StoreAsJson();
-                b.Property(p => p.GroupAttemptCounts).StoreAsJson();
                 b.Property(p => p.InputContentType).IsUnicode(false).HasMaxLength(200);
                 b.Property(p => p.ResponseMessageTypeName).IsUnicode(false).HasMaxLength(500);
 
@@ -283,6 +289,7 @@ namespace SW.Bitween
                 b.Property(p => p.ResponseName).HasMaxLength(200);
                 b.Property(p => p.ResponseContentType).IsUnicode(false).HasMaxLength(200);
                 b.Property(p => p.OutputContentType).IsUnicode(false).HasMaxLength(200);
+                b.Property(p => p.RetryBlockedReason).HasMaxLength(500);
 
 
                 b.HasOne<Xchange>().WithOne().HasForeignKey<XchangeResult>(p => p.Id).OnDelete(DeleteBehavior.Cascade);

--- a/SW.Bitween.Api/Domain/DelayedRetry.cs
+++ b/SW.Bitween.Api/Domain/DelayedRetry.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using SW.PrimitiveTypes;
 
 namespace SW.Bitween.Domain;
@@ -7,5 +6,4 @@ namespace SW.Bitween.Domain;
 public class DelayedRetry : BaseEntity<string>
 {
     public DateTime On { get; set; }
-    public Dictionary<string, int> GroupAttemptCounts { get; set; } = new();
 }

--- a/SW.Bitween.Api/Domain/RetryGroupUsage.cs
+++ b/SW.Bitween.Api/Domain/RetryGroupUsage.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace SW.Bitween.Domain;
+
+/// <summary>
+/// Running total of the retries one retry group has spent for one integration, backing
+/// <c>RetryBudget.MaxAttemptsTotal</c>.  That cap is shared by every message hitting the
+/// group, so it cannot be tracked on an individual xchange.
+/// </summary>
+/// <remarks>
+/// The total never resets on its own: once <see cref="AttemptsUsed"/> reaches the group's
+/// <c>MaxAttemptsTotal</c> the group stops retrying for that integration until this row is
+/// cleared.
+/// </remarks>
+public class RetryGroupUsage
+{
+    /// <summary>The integration whose budget this is. A shared policy gives each one its own total.</summary>
+    public int SubscriptionId { get; set; }
+
+    /// <summary><c>RetryGroup.Id</c>, which survives policy edits, so the total does too.</summary>
+    public Guid GroupId { get; set; }
+
+    public int AttemptsUsed { get; set; }
+
+    /// <summary>When the last attempt was claimed — the only clue left once a group is exhausted.</summary>
+    public DateTime LastAttemptOn { get; set; }
+}

--- a/SW.Bitween.Api/Domain/Xchange/Xchange.cs
+++ b/SW.Bitween.Api/Domain/Xchange/Xchange.cs
@@ -60,7 +60,7 @@ namespace SW.Bitween.Domain
         }
 
         //retry xchange
-        public Xchange(Xchange xchange, XchangeFile file, IWorkGroup workGroup, IReadOnlyDictionary<string, int> groupAttemptCounts = null) :
+        public Xchange(Xchange xchange, XchangeFile file, IWorkGroup workGroup) :
             this(xchange.DocumentId, workGroup, file, xchange.References)
         {
             SubscriptionId = xchange.SubscriptionId;
@@ -72,11 +72,10 @@ namespace SW.Bitween.Domain
             ResponseSubscriptionId = xchange.ResponseSubscriptionId;
             RetryFor = xchange.Id;
             CorrelationId = xchange.CorrelationId;
-            GroupAttemptCounts = groupAttemptCounts == null ? null : new Dictionary<string, int>(groupAttemptCounts);
         }
 
         //retry with reset subscription properties
-        public Xchange(Subscription subscription, Xchange xchange, XchangeFile file, IReadOnlyDictionary<string, int> groupAttemptCounts = null) :
+        public Xchange(Subscription subscription, Xchange xchange, XchangeFile file) :
             this(xchange.DocumentId, subscription.WorkGroup, file, xchange.References)
         {
             SubscriptionId = xchange.SubscriptionId;
@@ -88,7 +87,6 @@ namespace SW.Bitween.Domain
             ResponseSubscriptionId = subscription.ResponseSubscriptionId;
             RetryFor = xchange.Id;
             CorrelationId = xchange.CorrelationId;
-            GroupAttemptCounts = groupAttemptCounts == null ? null : new Dictionary<string, int>(groupAttemptCounts);
         }
 
         public int? SubscriptionId { get; private set; }
@@ -109,6 +107,5 @@ namespace SW.Bitween.Domain
 
         public string RetryFor { get; private set; }
         public string CorrelationId { get; set; }
-        public IReadOnlyDictionary<string, int> GroupAttemptCounts { get; private set; }
     }
 }

--- a/SW.Bitween.Api/Domain/XchangeResult/XchangeResult.cs
+++ b/SW.Bitween.Api/Domain/XchangeResult/XchangeResult.cs
@@ -62,6 +62,16 @@ namespace SW.Bitween.Domain
         public bool ResponseBad { get; private set; }
         public string ResponseContentType { get; private set; }
 
+        /// <summary>
+        /// Why the retry policy declined to schedule another attempt for this failure, or
+        /// <c>null</c> when a retry was scheduled or no policy applied. Without it a group that
+        /// has exhausted its budget looks identical to one that never matched.
+        /// </summary>
+        public string RetryBlockedReason { get; private set; }
+
+        /// <summary>Records the policy's refusal so it can be shown alongside the failure.</summary>
+        public void SetRetryBlocked(string reason) => RetryBlockedReason = reason;
+
 
 
     }

--- a/SW.Bitween.Api/Resources/RetryPolicies/Delete.cs
+++ b/SW.Bitween.Api/Resources/RetryPolicies/Delete.cs
@@ -28,7 +28,18 @@ public class Delete : IDeleteHandler<int, object>
         if (inUse)
             throw new SWException("Cannot delete a retry policy that is assigned to one or more subscriptions.");
 
+        // Same reason as Update: the policy's groups are about to stop existing, so clear their
+        // usage rows rather than strand them.
+        var policy = await _dbContext.FindAsync<RetryPolicy>(key);
+        var groupIds = policy.Groups.Select(g => g.Id).ToList();
+
         await _dbContext.DeleteByKeyAsync<RetryPolicy>(key);
+
+        if (groupIds.Count > 0)
+            await _dbContext.Set<RetryGroupUsage>()
+                .Where(u => groupIds.Contains(u.GroupId))
+                .ExecuteDeleteAsync();
+
         return null;
     }
 }

--- a/SW.Bitween.Api/Resources/RetryPolicies/ResetUsage.cs
+++ b/SW.Bitween.Api/Resources/RetryPolicies/ResetUsage.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using SW.Bitween.Domain;
+using SW.Bitween.Domain.Accounts;
+using SW.Bitween.Model;
+using SW.PrimitiveTypes;
+
+namespace SW.Bitween.Resources.RetryPolicies;
+
+/// <summary>
+/// Clears spent group budget, letting an exhausted group retry again. The total never resets on
+/// its own, so this is the only way back for an integration that has hit its ceiling.
+/// </summary>
+[HandlerName("resetusage")]
+public class ResetUsage : ICommandHandler<int, RetryPolicyResetUsage, object>
+{
+    private readonly BitweenDbContext _dbContext;
+    private readonly RequestContext _requestContext;
+
+    public ResetUsage(BitweenDbContext dbContext, RequestContext requestContext)
+    {
+        _dbContext = dbContext;
+        _requestContext = requestContext;
+    }
+
+    public async Task<object> Handle(int key, RetryPolicyResetUsage request)
+    {
+        _requestContext.EnsureAccess(AccountRole.Admin, AccountRole.Member);
+
+        var policy = await _dbContext.Set<RetryPolicy>().AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == key);
+        if (policy == null) throw new SWNotFoundException(key.ToString());
+
+        // Scope the reset to this policy's own integrations and groups, so a policy id in the
+        // route can never clear a counter belonging to a different policy.
+        var subscriptionIds = await _dbContext.Set<Subscription>()
+            .Where(s => s.RetryPolicyId == key)
+            .Select(s => s.Id)
+            .ToListAsync();
+
+        var groupIds = policy.Groups.Select(g => g.Id).ToList();
+
+        var query = _dbContext.Set<RetryGroupUsage>()
+            .Where(u => subscriptionIds.Contains(u.SubscriptionId) && groupIds.Contains(u.GroupId));
+
+        if (request.SubscriptionId.HasValue)
+            query = query.Where(u => u.SubscriptionId == request.SubscriptionId.Value);
+
+        if (request.GroupId.HasValue)
+            query = query.Where(u => u.GroupId == request.GroupId.Value);
+
+        await query.ExecuteDeleteAsync();
+        return null;
+    }
+}

--- a/SW.Bitween.Api/Resources/RetryPolicies/Test.cs
+++ b/SW.Bitween.Api/Resources/RetryPolicies/Test.cs
@@ -21,7 +21,7 @@ public class Test : ICommandHandler<TestRetryPolicyRequest, object>
         _requestContext = requestContext;
     }
 
-    public Task<object> Handle(TestRetryPolicyRequest request)
+    public async Task<object> Handle(TestRetryPolicyRequest request)
     {
         _requestContext.EnsureAccess(AccountRole.Admin, AccountRole.Member);
 
@@ -30,13 +30,14 @@ public class Test : ICommandHandler<TestRetryPolicyRequest, object>
                 "Choose Error or Bad result — a successful result is never retried.");
 
         var policy = new CustomRetryPolicy { Groups = request.Groups ?? [] };
-        var evaluator = new RetryPolicyEvaluator(policy);
+        // In-memory budget: a dry-run must not spend any real integration's total.
+        var evaluator = new RetryPolicyEvaluator(policy, new InMemoryRetryGroupBudget());
         var attemptsToSimulate = Math.Clamp(request.AttemptsToSimulate, 1, 20);
 
         var attempts = new List<TestRetryAttemptResult>();
         for (var attemptIndex = 0; attemptIndex < attemptsToSimulate; attemptIndex++)
         {
-            var decision = evaluator.Evaluate(request.ResultType, request.Content, attemptIndex);
+            var decision = await evaluator.Evaluate(request.ResultType, request.Content, attemptIndex);
 
             attempts.Add(new TestRetryAttemptResult
             {
@@ -53,6 +54,6 @@ public class Test : ICommandHandler<TestRetryPolicyRequest, object>
             if (!decision.ShouldRetry) break;
         }
 
-        return Task.FromResult<object>(new TestRetryPolicyResponse { Attempts = attempts });
+        return new TestRetryPolicyResponse { Attempts = attempts };
     }
 }

--- a/SW.Bitween.Api/Resources/RetryPolicies/Update.cs
+++ b/SW.Bitween.Api/Resources/RetryPolicies/Update.cs
@@ -1,4 +1,6 @@
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using SW.Bitween.Domain;
 using SW.Bitween.Domain.Accounts;
 using SW.Bitween.Model;
@@ -23,9 +25,23 @@ public class Update : ICommandHandler<int, RetryPolicyUpdate, object>
         RetryGroupValidation.EnsureCanFire(model.Groups);
 
         var entity = await _dbContext.FindAsync<RetryPolicy>(key);
+
+        // Spent budget is keyed by group id, so a group removed here would leave usage rows
+        // that no policy claims — invisible to the usage report and beyond the reach of reset.
+        var removedGroupIds = entity.Groups
+            .Select(g => g.Id)
+            .Except((model.Groups ?? []).Select(g => g.Id))
+            .ToList();
+
         entity.Name = model.Name;
         entity.Groups = model.Groups ?? [];
         await _dbContext.SaveChangesAsync();
+
+        if (removedGroupIds.Count > 0)
+            await _dbContext.Set<RetryGroupUsage>()
+                .Where(u => removedGroupIds.Contains(u.GroupId))
+                .ExecuteDeleteAsync();
+
         return null;
     }
 }

--- a/SW.Bitween.Api/Resources/RetryPolicies/Usage.cs
+++ b/SW.Bitween.Api/Resources/RetryPolicies/Usage.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using SW.Bitween.Domain;
+using SW.Bitween.Model;
+using SW.PrimitiveTypes;
+
+namespace SW.Bitween.Resources.RetryPolicies;
+
+/// <summary>
+/// Reports how much of each group's total budget the integrations using this policy have spent,
+/// so an exhausted group is visible instead of just silently declining to retry.
+/// </summary>
+[HandlerName("usage")]
+public class Usage : ICommandHandler<int, RetryPolicyUsageRequest, object>
+{
+    private readonly BitweenDbContext _dbContext;
+
+    public Usage(BitweenDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<object> Handle(int key, RetryPolicyUsageRequest request)
+    {
+        var policy = await _dbContext.Set<RetryPolicy>().AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == key);
+        if (policy == null) throw new SWNotFoundException(key.ToString());
+
+        var subscriptions = await _dbContext.Set<Subscription>().AsNoTracking()
+            .Where(s => s.RetryPolicyId == key)
+            .Select(s => new { s.Id, s.Name })
+            .ToListAsync();
+
+        var subscriptionIds = subscriptions.Select(s => s.Id).ToList();
+
+        var usages = await _dbContext.Set<RetryGroupUsage>().AsNoTracking()
+            .Where(u => subscriptionIds.Contains(u.SubscriptionId))
+            .ToListAsync();
+
+        // Only groups that allow retries have a budget to spend.
+        var budgets = policy.Groups
+            .Where(g => g.Budget != null)
+            .ToDictionary(g => g.Id, g => new { g.Name, g.Budget.MaxAttemptsTotal });
+
+        var names = subscriptions.ToDictionary(s => s.Id, s => s.Name);
+
+        var rows = usages
+            .Where(u => budgets.ContainsKey(u.GroupId))
+            .Select(u => new RetryGroupUsageRow
+            {
+                SubscriptionId = u.SubscriptionId,
+                SubscriptionName = names.GetValueOrDefault(u.SubscriptionId),
+                GroupId = u.GroupId,
+                GroupName = budgets[u.GroupId].Name,
+                AttemptsUsed = u.AttemptsUsed,
+                MaxAttemptsTotal = budgets[u.GroupId].MaxAttemptsTotal,
+                Exhausted = u.AttemptsUsed >= budgets[u.GroupId].MaxAttemptsTotal,
+                LastAttemptOn = u.LastAttemptOn
+            })
+            // Exhausted integrations first — those are the ones no longer being retried.
+            .OrderByDescending(r => r.Exhausted)
+            .ThenByDescending(r => r.AttemptsUsed)
+            .ToList();
+
+        return new List<RetryGroupUsageRow>(rows);
+    }
+}

--- a/SW.Bitween.Api/Resources/RetryPolicies/Usage.cs
+++ b/SW.Bitween.Api/Resources/RetryPolicies/Usage.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using SW.Bitween.Domain;
+using SW.Bitween.Domain.Accounts;
 using SW.Bitween.Model;
 using SW.PrimitiveTypes;
 
@@ -16,14 +17,18 @@ namespace SW.Bitween.Resources.RetryPolicies;
 public class Usage : ICommandHandler<int, RetryPolicyUsageRequest, object>
 {
     private readonly BitweenDbContext _dbContext;
+    private readonly RequestContext _requestContext;
 
-    public Usage(BitweenDbContext dbContext)
+    public Usage(BitweenDbContext dbContext, RequestContext requestContext)
     {
         _dbContext = dbContext;
+        _requestContext = requestContext;
     }
 
     public async Task<object> Handle(int key, RetryPolicyUsageRequest request)
     {
+        _requestContext.EnsureAccess(AccountRole.Admin, AccountRole.Member);
+
         var policy = await _dbContext.Set<RetryPolicy>().AsNoTracking()
             .FirstOrDefaultAsync(p => p.Id == key);
         if (policy == null) throw new SWNotFoundException(key.ToString());

--- a/SW.Bitween.Api/Resources/Xchanges/Search.cs
+++ b/SW.Bitween.Api/Resources/Xchanges/Search.cs
@@ -73,7 +73,8 @@ namespace SW.Bitween.Resources.Xchanges
                             ResponseFileName = result.ResponseName,
                             CorrelationId = xchange.CorrelationId,
                             PartnerId = subscriber.PartnerId,
-                            ScheduledRetryOn = delayedRetry != null ? delayedRetry.On : (DateTime?)null
+                            ScheduledRetryOn = delayedRetry != null ? delayedRetry.On : (DateTime?)null,
+                            RetryBlockedReason = result.RetryBlockedReason
                         };
 
             var condition = searchyRequest.Conditions.FirstOrDefault();

--- a/SW.Bitween.Api/Services/RetryGroupBudget.cs
+++ b/SW.Bitween.Api/Services/RetryGroupBudget.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using SW.Bitween.Domain;
+using SW.Bitween.Model;
+
+namespace SW.Bitween;
+
+/// <summary>
+/// <see cref="IRetryGroupBudget"/> backed by the <c>RetryGroupUsage</c> table and scoped to one
+/// integration, so a policy template shared by many integrations gives each its own total
+/// instead of letting one noisy integration spend everyone's budget.
+/// </summary>
+public class RetryGroupBudget(BitweenDbContext dbContext, int subscriptionId) : IRetryGroupBudget
+{
+    /// <inheritdoc/>
+    /// <remarks>
+    /// The increment is left for the caller's <c>SaveChangesAsync</c> so it commits in the same
+    /// transaction as the <c>DelayedRetry</c> row it authorises — a scheduled retry and its
+    /// spent slot can never disagree.  Two failures of the same group evaluated concurrently can
+    /// each read the same count and overshoot the cap by the number of simultaneous failures.
+    /// </remarks>
+    public async Task<bool> TryConsume(Guid groupId, int maxAttemptsTotal)
+    {
+        var usage = await dbContext.Set<RetryGroupUsage>()
+            .FirstOrDefaultAsync(u => u.SubscriptionId == subscriptionId && u.GroupId == groupId);
+
+        if ((usage?.AttemptsUsed ?? 0) >= maxAttemptsTotal) return false;
+
+        if (usage == null)
+            dbContext.Add(new RetryGroupUsage
+            {
+                SubscriptionId = subscriptionId,
+                GroupId = groupId,
+                AttemptsUsed = 1,
+                LastAttemptOn = DateTime.UtcNow
+            });
+        else
+        {
+            usage.AttemptsUsed++;
+            usage.LastAttemptOn = DateTime.UtcNow;
+        }
+
+        return true;
+    }
+}

--- a/SW.Bitween.Api/Services/RetryGroupBudget.cs
+++ b/SW.Bitween.Api/Services/RetryGroupBudget.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using SW.Bitween.Domain;
 using SW.Bitween.Model;
 
@@ -11,36 +13,70 @@ namespace SW.Bitween;
 /// integration, so a policy template shared by many integrations gives each its own total
 /// instead of letting one noisy integration spend everyone's budget.
 /// </summary>
-public class RetryGroupBudget(BitweenDbContext dbContext, int subscriptionId) : IRetryGroupBudget
+public class RetryGroupBudget(
+    BitweenDbContext dbContext,
+    IServiceProvider serviceProvider,
+    int subscriptionId) : IRetryGroupBudget
 {
     /// <inheritdoc/>
     /// <remarks>
-    /// The increment is left for the caller's <c>SaveChangesAsync</c> so it commits in the same
-    /// transaction as the <c>DelayedRetry</c> row it authorises — a scheduled retry and its
-    /// spent slot can never disagree.  Two failures of the same group evaluated concurrently can
-    /// each read the same count and overshoot the cap by the number of simultaneous failures.
+    /// <para>
+    /// The claim is a single conditional <c>UPDATE</c>, so the check and the increment happen as
+    /// one database operation. Bitween runs several instances, and a read-then-write would let two
+    /// simultaneous failures both observe the last free slot and both retry, exceeding the cap.
+    /// </para>
+    /// <para>
+    /// Because it commits on its own rather than with the caller's <c>SaveChangesAsync</c>, a slot
+    /// can be charged for a retry that is never scheduled if that later save fails. That errs
+    /// toward retrying less than the cap allows, and <c>RetryPolicies/resetusage</c> can return it.
+    /// The alternative — an explicit transaction spanning the caller's save — would publish this
+    /// xchange's bus events before the commit, since BitweenDbContext dispatches domain events
+    /// inside SaveChangesAsync.
+    /// </para>
     /// </remarks>
     public async Task<bool> TryConsume(Guid groupId, int maxAttemptsTotal)
     {
-        var usage = await dbContext.Set<RetryGroupUsage>()
-            .FirstOrDefaultAsync(u => u.SubscriptionId == subscriptionId && u.GroupId == groupId);
+        if (maxAttemptsTotal <= 0) return false;
 
-        if ((usage?.AttemptsUsed ?? 0) >= maxAttemptsTotal) return false;
+        if (await TryIncrement(dbContext, groupId, maxAttemptsTotal)) return true;
 
-        if (usage == null)
-            dbContext.Add(new RetryGroupUsage
-            {
-                SubscriptionId = subscriptionId,
-                GroupId = groupId,
-                AttemptsUsed = 1,
-                LastAttemptOn = DateTime.UtcNow
-            });
-        else
+        // Nothing was updated: either the ceiling is reached, or this integration and group have
+        // never failed before and so have no row yet.
+        var exists = await dbContext.Set<RetryGroupUsage>()
+            .AnyAsync(u => u.SubscriptionId == subscriptionId && u.GroupId == groupId);
+        if (exists) return false;
+
+        // Create that first row on its own context so it commits independently of whatever the
+        // caller still has pending. Losing this race is harmless: the primary key rejects the
+        // duplicate and the conditional increment is then applied to the winner's row.
+        using var scope = serviceProvider.CreateScope();
+        var isolated = scope.ServiceProvider.GetRequiredService<BitweenDbContext>();
+
+        isolated.Add(new RetryGroupUsage
         {
-            usage.AttemptsUsed++;
-            usage.LastAttemptOn = DateTime.UtcNow;
-        }
+            SubscriptionId = subscriptionId,
+            GroupId = groupId,
+            AttemptsUsed = 1,
+            LastAttemptOn = DateTime.UtcNow
+        });
 
-        return true;
+        try
+        {
+            await isolated.SaveChangesAsync();
+            return true;
+        }
+        catch (DbUpdateException)
+        {
+            return await TryIncrement(dbContext, groupId, maxAttemptsTotal);
+        }
     }
+
+    private async Task<bool> TryIncrement(BitweenDbContext db, Guid groupId, int maxAttemptsTotal) =>
+        await db.Set<RetryGroupUsage>()
+            .Where(u => u.SubscriptionId == subscriptionId
+                        && u.GroupId == groupId
+                        && u.AttemptsUsed < maxAttemptsTotal)
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(u => u.AttemptsUsed, u => u.AttemptsUsed + 1)
+                .SetProperty(u => u.LastAttemptOn, _ => DateTime.UtcNow)) > 0;
 }

--- a/SW.Bitween.Api/Services/XchangeService.cs
+++ b/SW.Bitween.Api/Services/XchangeService.cs
@@ -422,7 +422,8 @@ public class XchangeService :
                 responseXchange?.Id);
             _dbContext.Add(xchangeResult);
             if (responseFile?.BadData == true)
-                await TryScheduleAutoRetry(xchange, XchangeResultType.BadResult, responseFile.Data, xchangeResult);
+                await TrySchedulingWithoutLosingTheResult(xchange, XchangeResultType.BadResult, responseFile.Data,
+                    xchangeResult);
             await _dbContext.SaveChangesAsync();
         }
         catch (Exception ex)
@@ -430,8 +431,31 @@ public class XchangeService :
             var xchangeResult = new XchangeResult(xchange.Id, workGroup, outputFile, responseFile,
                 responseXchange?.Id, ex.ToString());
             _dbContext.Add(xchangeResult);
-            await TryScheduleAutoRetry(xchange, XchangeResultType.Error, ex.ToString(), xchangeResult);
+            await TrySchedulingWithoutLosingTheResult(xchange, XchangeResultType.Error, ex.ToString(), xchangeResult);
             await _dbContext.SaveChangesAsync();
+        }
+    }
+
+    /// <summary>
+    /// Evaluates the retry policy without ever costing the caller its failure record.
+    /// </summary>
+    /// <remarks>
+    /// Scheduling runs before the <see cref="XchangeResult"/> is saved and touches the database
+    /// several times. Letting it throw would replace the original exception with its own and abort
+    /// the save, so the failure would vanish from the UI entirely and only reappear as a silent
+    /// redelivery. Losing the retry is recoverable; losing the record of what went wrong is not.
+    /// </remarks>
+    private async Task TrySchedulingWithoutLosingTheResult(Xchange xchange, XchangeResultType resultType,
+        string content, XchangeResult xchangeResult)
+    {
+        try
+        {
+            await TryScheduleAutoRetry(xchange, resultType, content, xchangeResult);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Auto-retry evaluation failed for xchange {XchangeId}; the failure result is still recorded.",
+                xchange.Id);
         }
     }
 
@@ -455,7 +479,7 @@ public class XchangeService :
         if (policy?.Groups == null || policy.Groups.Count == 0) return;
 
         var evaluator = new RetryPolicyEvaluator(policy,
-            new RetryGroupBudget(_dbContext, xchange.SubscriptionId.Value));
+            new RetryGroupBudget(_dbContext, _serviceProvider, xchange.SubscriptionId.Value));
 
         var attemptIndex = await CountRetryChainDepth(xchange);
         var decision = await evaluator.Evaluate(resultType, content, attemptIndex);

--- a/SW.Bitween.Api/Services/XchangeService.cs
+++ b/SW.Bitween.Api/Services/XchangeService.cs
@@ -85,17 +85,17 @@ public class XchangeService :
         await _dbContext.SaveChangesAsync();
     }
 
-    public async Task CreateXchange(Xchange xchange, XchangeFile file, WorkGroup workGroup, Dictionary<string, int> groupAttemptCounts = null)
+    public async Task CreateXchange(Xchange xchange, XchangeFile file, WorkGroup workGroup)
     {
-        var newXchange = new Xchange(xchange, file, workGroup, groupAttemptCounts);
+        var newXchange = new Xchange(xchange, file, workGroup);
         await AddFile(newXchange.Id, XchangeFileType.Input, file);
         _dbContext.Add(newXchange);
     }
 
     public async Task CreateXchange(Subscription subscription, Xchange xchange, XchangeFile file,
-        string[] references = null, Dictionary<string, int> groupAttemptCounts = null)
+        string[] references = null)
     {
-        var newXchange = new Xchange(subscription, xchange, file, groupAttemptCounts);
+        var newXchange = new Xchange(subscription, xchange, file);
         await AddFile(newXchange.Id, XchangeFileType.Input, file);
         _dbContext.Add(newXchange);
     }
@@ -147,7 +147,7 @@ public class XchangeService :
 
         var inputFileData = await GetFile(xchange.Id, XchangeFileType.Input);
         var inputFile = new XchangeFile(inputFileData, xchange.InputName);
-        await CreateXchange(subscription, xchange, inputFile, groupAttemptCounts: delayedRetry.GroupAttemptCounts);
+        await CreateXchange(subscription, xchange, inputFile);
         _dbContext.Remove(delayedRetry);
         return true;
     }
@@ -418,23 +418,34 @@ public class XchangeService :
                 await CreateXchangesForHits(xchange, result, inputFile);
             }
 
-            _dbContext.Add(new XchangeResult(xchange.Id, workGroup, outputFile, responseFile, responseXchange?.Id));
+            var xchangeResult = new XchangeResult(xchange.Id, workGroup, outputFile, responseFile,
+                responseXchange?.Id);
+            _dbContext.Add(xchangeResult);
             if (responseFile?.BadData == true)
-                await TryScheduleAutoRetry(xchange, XchangeResultType.BadResult, responseFile.Data);
+                await TryScheduleAutoRetry(xchange, XchangeResultType.BadResult, responseFile.Data, xchangeResult);
             await _dbContext.SaveChangesAsync();
         }
         catch (Exception ex)
         {
-            _dbContext.Add(new XchangeResult(xchange.Id, workGroup, outputFile, responseFile, responseXchange?.Id,
-                ex.ToString()));
-            await TryScheduleAutoRetry(xchange, XchangeResultType.Error, ex.ToString());
+            var xchangeResult = new XchangeResult(xchange.Id, workGroup, outputFile, responseFile,
+                responseXchange?.Id, ex.ToString());
+            _dbContext.Add(xchangeResult);
+            await TryScheduleAutoRetry(xchange, XchangeResultType.Error, ex.ToString(), xchangeResult);
             await _dbContext.SaveChangesAsync();
         }
     }
 
-    private async Task TryScheduleAutoRetry(Xchange xchange, XchangeResultType resultType, string content)
+    private async Task TryScheduleAutoRetry(Xchange xchange, XchangeResultType resultType, string content,
+        XchangeResult xchangeResult)
     {
         if (xchange.SubscriptionId == null) return;
+
+        // DelayedRetry.Id is xchange.Id, so an existing row means this failure was already
+        // evaluated and already spent a slot of the group's total budget. Re-evaluating it
+        // (e.g. on an at-least-once redelivery) would both violate the PK on Add and spend a
+        // second slot for the same failure.
+        var alreadyScheduled = await _dbContext.Set<DelayedRetry>().FindAsync(xchange.Id);
+        if (alreadyScheduled != null) return;
 
         var subscription = await _dbContext.Set<Subscription>()
             .Include(s => s.RetryPolicy)
@@ -443,35 +454,22 @@ public class XchangeService :
         IRetryPolicy policy = subscription?.CustomRetryPolicy ?? (IRetryPolicy)subscription?.RetryPolicy;
         if (policy?.Groups == null || policy.Groups.Count == 0) return;
 
-        var evaluator = new RetryPolicyEvaluator(policy);
-        evaluator.RestoreGroupAttemptCounts(xchange.GroupAttemptCounts == null
-            ? new Dictionary<string, int>()
-            : new Dictionary<string, int>(xchange.GroupAttemptCounts));
+        var evaluator = new RetryPolicyEvaluator(policy,
+            new RetryGroupBudget(_dbContext, xchange.SubscriptionId.Value));
 
         var attemptIndex = await CountRetryChainDepth(xchange);
-        var decision = evaluator.Evaluate(resultType, content, attemptIndex);
+        var decision = await evaluator.Evaluate(resultType, content, attemptIndex);
 
         if (decision.ShouldRetry)
-        {
-            // Guard against duplicate scheduling (e.g. an at-least-once redelivery
-            // reprocessing the same xchange) — DelayedRetry.Id is xchange.Id, so a
-            // blind Add would violate the PK and fail the whole SaveChangesAsync.
-            var existing = await _dbContext.Set<DelayedRetry>().FindAsync(xchange.Id);
-            if (existing != null)
+            _dbContext.Add(new DelayedRetry
             {
-                existing.On = DateTime.UtcNow + decision.Delay;
-                existing.GroupAttemptCounts = evaluator.GetGroupAttemptCounts();
-            }
-            else
-            {
-                _dbContext.Add(new DelayedRetry
-                {
-                    Id = xchange.Id,
-                    On = DateTime.UtcNow + decision.Delay,
-                    GroupAttemptCounts = evaluator.GetGroupAttemptCounts()
-                });
-            }
-        }
+                Id = xchange.Id,
+                On = DateTime.UtcNow + decision.Delay
+            });
+        else
+            // A policy applied but refused. Recorded so an exhausted budget is distinguishable
+            // from an error no group was ever configured to catch.
+            xchangeResult.SetRetryBlocked(decision.Reason);
     }
 
     private async Task<int> CountRetryChainDepth(Xchange xchange)

--- a/SW.Bitween.IntegrationTests/Tests/RetryJobTests.cs
+++ b/SW.Bitween.IntegrationTests/Tests/RetryJobTests.cs
@@ -122,15 +122,10 @@ public class RetryJobTests
         // Use CreateXchange so the input file is uploaded to real cloud storage
         var originalXchange = await xs.CreateXchange(sub, new XchangeFile("{}"));
 
-        var groupCounts = new System.Collections.Generic.Dictionary<string, int>
-        {
-            [Guid.NewGuid().ToString()] = 1
-        };
         var delayedRetry = new DelayedRetry
         {
             Id = originalXchange.Id,
-            On = DateTime.UtcNow.AddMinutes(-1),
-            GroupAttemptCounts = groupCounts
+            On = DateTime.UtcNow.AddMinutes(-1)
         };
         db.Set<DelayedRetry>().Add(delayedRetry);
         await db.SaveChangesAsync();
@@ -147,47 +142,6 @@ public class RetryJobTests
         Assert.NotNull(retryXchange);
         Assert.Equal(originalXchange.Id, retryXchange.RetryFor);
         Assert.Equal(sub.Id, retryXchange.SubscriptionId);
-    }
-
-    [Fact]
-    public async Task RetryJob_carries_group_attempt_counts_onto_retry_xchange()
-    {
-        await using var scope = _fixture.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<BitweenDbContext>();
-        var xs = scope.ServiceProvider.GetRequiredService<XchangeService>();
-
-        var doc = new Document(8002, "RetryJob GroupCounts Doc");
-        db.Set<Document>().Add(doc);
-        await db.SaveChangesAsync();
-
-        var sub = new Subscription("RetryJob GroupCounts Sub", doc.Id);
-        sub.Inactive = false;
-        db.Set<Subscription>().Add(sub);
-        await db.SaveChangesAsync();
-
-        var originalXchange = await xs.CreateXchange(sub, new XchangeFile("{}"));
-
-        var groupId = Guid.NewGuid().ToString();
-        var delayedRetry = new DelayedRetry
-        {
-            Id = originalXchange.Id,
-            On = DateTime.UtcNow.AddMinutes(-1),
-            GroupAttemptCounts = new System.Collections.Generic.Dictionary<string, int>
-            {
-                [groupId] = 2
-            }
-        };
-        db.Set<DelayedRetry>().Add(delayedRetry);
-        await db.SaveChangesAsync();
-
-        await BuildJob(db, xs).Execute();
-
-        var retryXchange = await db.Set<Xchange>()
-            .FirstOrDefaultAsync(x => x.RetryFor == originalXchange.Id);
-        Assert.NotNull(retryXchange);
-        Assert.NotNull(retryXchange.GroupAttemptCounts);
-        Assert.True(retryXchange.GroupAttemptCounts.TryGetValue(groupId, out var count));
-        Assert.Equal(2, count);
     }
 
     [Fact]

--- a/SW.Bitween.IntegrationTests/Tests/RetryPolicyTests.cs
+++ b/SW.Bitween.IntegrationTests/Tests/RetryPolicyTests.cs
@@ -370,7 +370,7 @@ public class RetryPolicyTests
         for (var attempt = 0; attempt < 3; attempt++)
         {
             // A fresh evaluator and store per failure, exactly as XchangeService builds them.
-            var evaluator = new RetryPolicyEvaluator(policy, new RetryGroupBudget(db, sub.Id));
+            var evaluator = new RetryPolicyEvaluator(policy, new RetryGroupBudget(db, scope.ServiceProvider, sub.Id));
             var decision = await evaluator.Evaluate(XchangeResultType.Error, "timeout", attempt);
             if (decision.ShouldRetry) allowed++;
             await db.SaveChangesAsync();
@@ -421,11 +421,46 @@ public class RetryPolicyTests
 
         async Task<bool> Allow(int subscriptionId)
         {
-            var evaluator = new RetryPolicyEvaluator(policy, new RetryGroupBudget(db, subscriptionId));
+            var evaluator = new RetryPolicyEvaluator(policy, new RetryGroupBudget(db, scope.ServiceProvider, subscriptionId));
             var decision = await evaluator.Evaluate(XchangeResultType.Error, "timeout", 0);
             await db.SaveChangesAsync();
             return decision.ShouldRetry;
         }
+    }
+
+    [Fact]
+    public async Task Concurrent_claims_never_exceed_the_group_total()
+    {
+        await using var setup = _fixture.CreateScope();
+        var setupDb = setup.ServiceProvider.GetRequiredService<BitweenDbContext>();
+
+        var doc = new Document(7010, "Concurrent Budget Doc");
+        setupDb.Set<Document>().Add(doc);
+        var sub = new Subscription("Concurrent Budget Sub", doc.Id);
+        setupDb.Set<Subscription>().Add(sub);
+        await setupDb.SaveChangesAsync();
+
+        var groupId = Guid.NewGuid();
+        const int cap = 5;
+        const int racers = 16;
+
+        // Bitween runs several instances, so simultaneous failures of the same integration and
+        // group are normal. Each racer gets its own scope and context, mimicking separate
+        // instances: a read-then-write would let several observe the same free slot at once.
+        var tasks = Enumerable.Range(0, racers).Select(async _ =>
+        {
+            await using var scope = _fixture.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<BitweenDbContext>();
+            return await new RetryGroupBudget(db, scope.ServiceProvider, sub.Id).TryConsume(groupId, cap);
+        });
+
+        var granted = (await Task.WhenAll(tasks)).Count(allowed => allowed);
+
+        Assert.Equal(cap, granted);
+
+        var usage = await setupDb.Set<RetryGroupUsage>().AsNoTracking()
+            .SingleAsync(u => u.SubscriptionId == sub.Id && u.GroupId == groupId);
+        Assert.Equal(cap, usage.AttemptsUsed);
     }
 
     // ─── Usage reporting and reset ──────────────────────────────────────────────
@@ -452,11 +487,11 @@ public class RetryPolicyTests
         await db.SaveChangesAsync();
 
         // Spend the whole budget (SimplePolicy allows 10 in total).
-        var budget = new RetryGroupBudget(db, sub.Id);
+        var budget = new RetryGroupBudget(db, scope.ServiceProvider, sub.Id);
         for (var i = 0; i < 10; i++) await budget.TryConsume(groupId, 10);
         await db.SaveChangesAsync();
 
-        var rows = (List<RetryGroupUsageRow>)await new Usage(db).Handle(policyId, new RetryPolicyUsageRequest());
+        var rows = (List<RetryGroupUsageRow>)await new Usage(db, ctx).Handle(policyId, new RetryPolicyUsageRequest());
         var row = Assert.Single(rows);
         Assert.Equal(sub.Id, row.SubscriptionId);
         Assert.Equal("Usage Sub", row.SubscriptionName);
@@ -470,10 +505,10 @@ public class RetryPolicyTests
             GroupId = groupId
         });
 
-        Assert.Empty((List<RetryGroupUsageRow>)await new Usage(db).Handle(policyId, new RetryPolicyUsageRequest()));
+        Assert.Empty((List<RetryGroupUsageRow>)await new Usage(db, ctx).Handle(policyId, new RetryPolicyUsageRequest()));
 
         // And the group can retry again.
-        Assert.True(await new RetryGroupBudget(db, sub.Id).TryConsume(groupId, 10));
+        Assert.True(await new RetryGroupBudget(db, scope.ServiceProvider, sub.Id).TryConsume(groupId, 10));
     }
 
     [Fact]
@@ -498,13 +533,49 @@ public class RetryPolicyTests
         otherSub.SetRetryPolicy(otherId, null);
         await db.SaveChangesAsync();
 
-        await new RetryGroupBudget(db, otherSub.Id).TryConsume(otherGroupId, 10);
+        await new RetryGroupBudget(db, scope.ServiceProvider, otherSub.Id).TryConsume(otherGroupId, 10);
         await db.SaveChangesAsync();
 
         // Resetting everything under one policy must leave the other policy's counters alone.
         await new ResetUsage(db, ctx).Handle(mineId, new RetryPolicyResetUsage());
 
-        Assert.Single((List<RetryGroupUsageRow>)await new Usage(db).Handle(otherId, new RetryPolicyUsageRequest()));
+        Assert.Single((List<RetryGroupUsageRow>)await new Usage(db, ctx).Handle(otherId, new RetryPolicyUsageRequest()));
+    }
+
+    [Fact]
+    public async Task Removing_a_group_clears_its_spent_budget()
+    {
+        await using var scope = _fixture.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<BitweenDbContext>();
+        var ctx = scope.ServiceProvider.GetRequiredService<RequestContext>();
+
+        var doc = new Document(7009, "Removed Group Doc");
+        db.Set<Document>().Add(doc);
+        await db.SaveChangesAsync();
+
+        var policyId = (int)await new Create(db, ctx).Handle(SimplePolicy("Removed Group Policy"));
+        var saved = await db.Set<RetryPolicy>().AsNoTracking().SingleAsync(p => p.Id == policyId);
+        var groupId = saved.Groups[0].Id;
+
+        var sub = new Subscription("Removed Group Sub", doc.Id);
+        db.Set<Subscription>().Add(sub);
+        await db.SaveChangesAsync();
+        sub.SetRetryPolicy(policyId, null);
+        await db.SaveChangesAsync();
+
+        await new RetryGroupBudget(db, scope.ServiceProvider, sub.Id).TryConsume(groupId, 10);
+        await db.SaveChangesAsync();
+        Assert.True(await db.Set<RetryGroupUsage>().AnyAsync(u => u.GroupId == groupId));
+
+        // Dropping the group must take its counter with it, or the row is stranded where
+        // neither the usage report nor reset can reach it.
+        await new Update(db, ctx).Handle(policyId, new RetryPolicyUpdate
+        {
+            Name = "Removed Group Policy",
+            Groups = []
+        });
+
+        Assert.False(await db.Set<RetryGroupUsage>().AnyAsync(u => u.GroupId == groupId));
     }
 
     // ─── Test / dry-run endpoint ────────────────────────────────────────────────

--- a/SW.Bitween.IntegrationTests/Tests/RetryPolicyTests.cs
+++ b/SW.Bitween.IntegrationTests/Tests/RetryPolicyTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -331,6 +332,179 @@ public class RetryPolicyTests
 
         var reloaded = await db.Set<Subscription>().AsNoTracking().SingleAsync(s => s.Id == sub.Id);
         Assert.Null(reloaded.RetryPolicyId);
+    }
+
+    // ─── Shared group total (MaxAttemptsTotal) ──────────────────────────────────
+
+    [Fact]
+    public async Task Group_total_is_shared_across_separate_messages_of_the_same_integration()
+    {
+        await using var scope = _fixture.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<BitweenDbContext>();
+
+        var doc = new Document(7005, "Shared Total Doc");
+        db.Set<Document>().Add(doc);
+        var sub = new Subscription("Shared Total Sub", doc.Id);
+        db.Set<Subscription>().Add(sub);
+        await db.SaveChangesAsync();
+
+        var group = new RetryGroup
+        {
+            Name = "Timeout",
+            Priority = 10,
+            AppliesTo = [XchangeResultType.Error],
+            Matchers = [new ContainsMatcher { Value = "timeout" }],
+            Budget = new RetryBudget
+            {
+                MaxAttemptsPerError = 3,
+                MaxAttemptsTotal = 10,
+                DelayStrategy = new FixedDelayStrategy { DelayMs = 5_000 }
+            }
+        };
+        var policy = new CustomRetryPolicy { Groups = [group] };
+
+        // Reproduces the reported bug: four failing messages, each retried up to its own
+        // per-message cap of 3, under a shared total of 10 — 12 retries before the fix.
+        var allowed = 0;
+        for (var message = 0; message < 4; message++)
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            // A fresh evaluator and store per failure, exactly as XchangeService builds them.
+            var evaluator = new RetryPolicyEvaluator(policy, new RetryGroupBudget(db, sub.Id));
+            var decision = await evaluator.Evaluate(XchangeResultType.Error, "timeout", attempt);
+            if (decision.ShouldRetry) allowed++;
+            await db.SaveChangesAsync();
+        }
+
+        Assert.Equal(10, allowed);
+
+        var usage = await db.Set<RetryGroupUsage>().AsNoTracking()
+            .SingleAsync(u => u.SubscriptionId == sub.Id && u.GroupId == group.Id);
+        Assert.Equal(10, usage.AttemptsUsed);
+    }
+
+    [Fact]
+    public async Task Group_total_is_tracked_per_integration_not_per_policy()
+    {
+        await using var scope = _fixture.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<BitweenDbContext>();
+
+        var doc = new Document(7006, "Per Integration Doc");
+        db.Set<Document>().Add(doc);
+        var subA = new Subscription("Per Integration Sub A", doc.Id);
+        var subB = new Subscription("Per Integration Sub B", doc.Id);
+        db.Set<Subscription>().AddRange(subA, subB);
+        await db.SaveChangesAsync();
+
+        var group = new RetryGroup
+        {
+            Name = "Timeout",
+            Priority = 10,
+            AppliesTo = [XchangeResultType.Error],
+            Matchers = [new ContainsMatcher { Value = "timeout" }],
+            Budget = new RetryBudget
+            {
+                MaxAttemptsPerError = 10,
+                MaxAttemptsTotal = 1,
+                DelayStrategy = new FixedDelayStrategy { DelayMs = 5_000 }
+            }
+        };
+        var policy = new CustomRetryPolicy { Groups = [group] };
+
+        // Each integration gets its own single attempt, so one integration exhausting a
+        // shared policy template cannot starve the others.
+        Assert.True(await Allow(subA.Id));
+        Assert.True(await Allow(subB.Id));
+        Assert.False(await Allow(subA.Id));
+        Assert.False(await Allow(subB.Id));
+        return;
+
+        async Task<bool> Allow(int subscriptionId)
+        {
+            var evaluator = new RetryPolicyEvaluator(policy, new RetryGroupBudget(db, subscriptionId));
+            var decision = await evaluator.Evaluate(XchangeResultType.Error, "timeout", 0);
+            await db.SaveChangesAsync();
+            return decision.ShouldRetry;
+        }
+    }
+
+    // ─── Usage reporting and reset ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task Usage_reports_spent_budget_and_reset_clears_it()
+    {
+        await using var scope = _fixture.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<BitweenDbContext>();
+        var ctx = scope.ServiceProvider.GetRequiredService<RequestContext>();
+
+        var doc = new Document(7007, "Usage Doc");
+        db.Set<Document>().Add(doc);
+        await db.SaveChangesAsync();
+
+        var policyId = (int)await new Create(db, ctx).Handle(SimplePolicy("Usage Policy"));
+        var saved = await db.Set<RetryPolicy>().AsNoTracking().SingleAsync(p => p.Id == policyId);
+        var groupId = saved.Groups[0].Id;
+
+        var sub = new Subscription("Usage Sub", doc.Id);
+        db.Set<Subscription>().Add(sub);
+        await db.SaveChangesAsync();
+        sub.SetRetryPolicy(policyId, null);
+        await db.SaveChangesAsync();
+
+        // Spend the whole budget (SimplePolicy allows 10 in total).
+        var budget = new RetryGroupBudget(db, sub.Id);
+        for (var i = 0; i < 10; i++) await budget.TryConsume(groupId, 10);
+        await db.SaveChangesAsync();
+
+        var rows = (List<RetryGroupUsageRow>)await new Usage(db).Handle(policyId, new RetryPolicyUsageRequest());
+        var row = Assert.Single(rows);
+        Assert.Equal(sub.Id, row.SubscriptionId);
+        Assert.Equal("Usage Sub", row.SubscriptionName);
+        Assert.Equal("Timeout", row.GroupName);
+        Assert.Equal(10, row.AttemptsUsed);
+        Assert.True(row.Exhausted);
+
+        await new ResetUsage(db, ctx).Handle(policyId, new RetryPolicyResetUsage
+        {
+            SubscriptionId = sub.Id,
+            GroupId = groupId
+        });
+
+        Assert.Empty((List<RetryGroupUsageRow>)await new Usage(db).Handle(policyId, new RetryPolicyUsageRequest()));
+
+        // And the group can retry again.
+        Assert.True(await new RetryGroupBudget(db, sub.Id).TryConsume(groupId, 10));
+    }
+
+    [Fact]
+    public async Task Reset_does_not_touch_counters_of_another_policy()
+    {
+        await using var scope = _fixture.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<BitweenDbContext>();
+        var ctx = scope.ServiceProvider.GetRequiredService<RequestContext>();
+
+        var doc = new Document(7008, "Reset Scope Doc");
+        db.Set<Document>().Add(doc);
+        await db.SaveChangesAsync();
+
+        var mineId = (int)await new Create(db, ctx).Handle(SimplePolicy("Reset Scope Mine"));
+        var otherId = (int)await new Create(db, ctx).Handle(SimplePolicy("Reset Scope Other"));
+        var otherGroupId = (await db.Set<RetryPolicy>().AsNoTracking()
+            .SingleAsync(p => p.Id == otherId)).Groups[0].Id;
+
+        var otherSub = new Subscription("Reset Scope Other Sub", doc.Id);
+        db.Set<Subscription>().Add(otherSub);
+        await db.SaveChangesAsync();
+        otherSub.SetRetryPolicy(otherId, null);
+        await db.SaveChangesAsync();
+
+        await new RetryGroupBudget(db, otherSub.Id).TryConsume(otherGroupId, 10);
+        await db.SaveChangesAsync();
+
+        // Resetting everything under one policy must leave the other policy's counters alone.
+        await new ResetUsage(db, ctx).Handle(mineId, new RetryPolicyResetUsage());
+
+        Assert.Single((List<RetryGroupUsageRow>)await new Usage(db).Handle(otherId, new RetryPolicyUsageRequest()));
     }
 
     // ─── Test / dry-run endpoint ────────────────────────────────────────────────

--- a/SW.Bitween.MsSql/Migrations/20260811081235_SharedRetryGroupTotals.Designer.cs
+++ b/SW.Bitween.MsSql/Migrations/20260811081235_SharedRetryGroupTotals.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SW.Bitween.MsSql;
 
@@ -11,9 +12,11 @@ using SW.Bitween.MsSql;
 namespace SW.Bitween.MsSql.Migrations
 {
     [DbContext(typeof(BitweenDbContext))]
-    partial class BitweenDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811081235_SharedRetryGroupTotals")]
+    partial class SharedRetryGroupTotals
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1010,10 +1013,6 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("ResponseXchangeId")
                         .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("RetryBlockedReason")
-                        .HasMaxLength(500)
-                        .HasColumnType("nvarchar(500)");
 
                     b.Property<bool>("Success")
                         .HasColumnType("bit");

--- a/SW.Bitween.MsSql/Migrations/20260811081235_SharedRetryGroupTotals.cs
+++ b/SW.Bitween.MsSql/Migrations/20260811081235_SharedRetryGroupTotals.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SW.Bitween.MsSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class SharedRetryGroupTotals : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GroupAttemptCounts",
+                table: "Xchanges");
+
+            migrationBuilder.DropColumn(
+                name: "GroupAttemptCounts",
+                table: "DelayedRetries");
+
+            migrationBuilder.CreateTable(
+                name: "RetryGroupUsages",
+                columns: table => new
+                {
+                    SubscriptionId = table.Column<int>(type: "int", nullable: false),
+                    GroupId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    AttemptsUsed = table.Column<int>(type: "int", nullable: false),
+                    LastAttemptOn = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RetryGroupUsages", x => new { x.SubscriptionId, x.GroupId });
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RetryGroupUsages");
+
+            migrationBuilder.AddColumn<string>(
+                name: "GroupAttemptCounts",
+                table: "Xchanges",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GroupAttemptCounts",
+                table: "DelayedRetries",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/SW.Bitween.MsSql/Migrations/20260811092327_RetryBlockedReason.Designer.cs
+++ b/SW.Bitween.MsSql/Migrations/20260811092327_RetryBlockedReason.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SW.Bitween.MsSql;
 
@@ -11,9 +12,11 @@ using SW.Bitween.MsSql;
 namespace SW.Bitween.MsSql.Migrations
 {
     [DbContext(typeof(BitweenDbContext))]
-    partial class BitweenDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811092327_RetryBlockedReason")]
+    partial class RetryBlockedReason
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SW.Bitween.MsSql/Migrations/20260811092327_RetryBlockedReason.cs
+++ b/SW.Bitween.MsSql/Migrations/20260811092327_RetryBlockedReason.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SW.Bitween.MsSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class RetryBlockedReason : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "RetryBlockedReason",
+                table: "XchangeResults",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RetryBlockedReason",
+                table: "XchangeResults");
+        }
+    }
+}

--- a/SW.Bitween.MySql/Migrations/20260811081221_SharedRetryGroupTotals.Designer.cs
+++ b/SW.Bitween.MySql/Migrations/20260811081221_SharedRetryGroupTotals.Designer.cs
@@ -3,24 +3,27 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using SW.Bitween.MsSql;
+using SW.Bitween.MySql;
 
 #nullable disable
 
-namespace SW.Bitween.MsSql.Migrations
+namespace SW.Bitween.MySql.Migrations
 {
     [DbContext(typeof(BitweenDbContext))]
-    partial class BitweenDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811081221_SharedRetryGroupTotals")]
+    partial class SharedRetryGroupTotals
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "8.0.23")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
             modelBuilder.Entity("SW.Bitween.Domain.Accounts.Account", b =>
                 {
@@ -28,24 +31,24 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool>("Deleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("Disabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<string>("Email")
                         .HasMaxLength(200)
@@ -53,16 +56,16 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<byte>("EmailProvider")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<byte>("LoginMethods")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Password")
                         .HasMaxLength(500)
@@ -80,8 +83,7 @@ namespace SW.Bitween.MsSql.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("Email")
-                        .IsUnique()
-                        .HasFilter("[Email] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("Accounts", (string)null);
 
@@ -112,10 +114,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte>("LoginMethod")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.HasKey("Id");
 
@@ -132,7 +134,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<DateTime>("On")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("Id");
 
@@ -147,7 +149,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<bool>("BusEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("BusMessageTypeName")
                         .HasMaxLength(500)
@@ -155,7 +157,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(500)");
 
                     b.Property<bool?>("DisregardsUnfilteredMessages")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("DocumentFormat")
                         .HasColumnType("int");
@@ -170,13 +172,12 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(100)");
 
                     b.Property<string>("PromotedProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
                     b.HasIndex("BusMessageTypeName")
-                        .IsUnique()
-                        .HasFilter("[BusMessageTypeName] IS NOT NULL");
+                        .IsUnique();
 
                     b.HasIndex("Name")
                         .IsUnique();
@@ -199,25 +200,25 @@ namespace SW.Bitween.MsSql.Migrations
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<int>("Code")
                         .HasColumnType("int");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("DocumentId")
                         .HasColumnType("int");
 
                     b.Property<string>("StateAfter")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("StateBefore")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -234,29 +235,29 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<string>("UrlName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.HasKey("Id");
 
@@ -278,16 +279,16 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("ApiGatewayId", "PartnerId", "SubscriptionId");
 
@@ -304,27 +305,27 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("DocumentId")
                         .HasColumnType("int");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.HasKey("Id");
 
@@ -339,25 +340,25 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<int>("BusGatewayId")
                         .HasColumnType("int");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("MatchExpression")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int?>("PartnerId")
                         .HasColumnType("int");
@@ -384,10 +385,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Values")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -400,7 +401,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("HandlerId")
                         .HasMaxLength(200)
@@ -408,27 +409,27 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("HandlerProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Inactive")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("varchar(100)");
 
                     b.Property<bool>("RunOnBadResult")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("RunOnFailedResult")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("RunOnSubscriptions")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("RunOnSuccessfulResult")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("Id");
 
@@ -441,20 +442,20 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<bool>("BadData")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("FileName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("References")
                         .HasMaxLength(1024)
-                        .HasColumnType("nvarchar(1024)");
+                        .HasColumnType("varchar(1024)");
 
                     b.Property<int>("SubscriptionId")
                         .HasColumnType("int");
@@ -472,10 +473,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("AdapterProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -501,13 +502,13 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<Guid>("GroupId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<int>("AttemptsUsed")
                         .HasColumnType("int");
 
                     b.Property<DateTime>("LastAttemptOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("SubscriptionId", "GroupId");
 
@@ -520,27 +521,27 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Groups")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.HasKey("Id");
 
@@ -553,16 +554,16 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<DateTime?>("AggregateOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int?>("AggregationForId")
                         .HasColumnType("int");
 
                     b.Property<byte>("AggregationTarget")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<int?>("CategoryId")
                         .HasColumnType("int");
@@ -571,10 +572,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<string>("CustomRetryPolicy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("DocumentFilter")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("DocumentId")
                         .HasColumnType("int");
@@ -585,16 +586,16 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("HandlerProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Inactive")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsRunning")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("LastException")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("MapperId")
                         .HasMaxLength(200)
@@ -602,24 +603,24 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("MapperProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("MatchExpression")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("varchar(100)");
 
                     b.Property<int?>("PartnerId")
                         .HasColumnType("int");
 
                     b.Property<DateTime?>("PausedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime?>("ReceiveOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ReceiverId")
                         .HasMaxLength(200)
@@ -627,7 +628,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("ReceiverProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ResponseMessageTypeName")
                         .HasMaxLength(500)
@@ -641,10 +642,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<bool>("Temporary")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<byte>("Type")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("ValidatorId")
                         .HasMaxLength(200)
@@ -652,7 +653,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("ValidatorProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int?>("WorkGroupId")
                         .HasColumnType("int");
@@ -682,31 +683,30 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Code")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("Code")
-                        .IsUnique()
-                        .HasFilter("[Code] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("SubscriptionCategory");
                 });
@@ -715,22 +715,22 @@ namespace SW.Bitween.MsSql.Migrations
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<int>("Code")
                         .HasColumnType("int");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("StateAfter")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("StateBefore")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("SubscriptionId")
                         .HasColumnType("int");
@@ -750,7 +750,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("BusMessageName")
                         .IsRequired()
@@ -759,10 +759,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(100)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Options")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -777,7 +777,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<string>("CorrelationId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("DocumentId")
                         .HasColumnType("int");
@@ -788,7 +788,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("HandlerProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("InputContentType")
                         .HasMaxLength(200)
@@ -803,7 +803,7 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("InputName")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<int>("InputSize")
                         .HasColumnType("int");
@@ -814,14 +814,14 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("MapperProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int?>("PartnerId")
                         .HasColumnType("int");
 
                     b.Property<string>("References")
                         .HasMaxLength(1024)
-                        .HasColumnType("nvarchar(1024)");
+                        .HasColumnType("varchar(1024)");
 
                     b.Property<string>("ResponseMessageTypeName")
                         .HasMaxLength(500)
@@ -837,7 +837,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<DateTime>("StartedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int?>("SubscriptionId")
                         .HasColumnType("int");
@@ -865,7 +865,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<DateTime>("AggregatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("AggregationXchangeId")
                         .IsRequired()
@@ -888,7 +888,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<DateTime>("DeliveredOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("Id");
 
@@ -903,22 +903,22 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Exception")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("FinishedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("NotifierId")
                         .HasColumnType("int");
 
                     b.Property<string>("NotifierName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Success")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("XchangeId")
                         .HasMaxLength(50)
@@ -943,10 +943,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(2000)");
 
                     b.Property<string>("Properties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("PropertiesRaw")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.HasKey("Id");
 
@@ -963,13 +963,13 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<string>("Exception")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("FinishedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool>("OutputBad")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("OutputContentType")
                         .HasMaxLength(200)
@@ -983,13 +983,13 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("OutputName")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<int>("OutputSize")
                         .HasColumnType("int");
 
                     b.Property<bool>("ResponseBad")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("ResponseContentType")
                         .HasMaxLength(200)
@@ -1003,20 +1003,16 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("ResponseName")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<int>("ResponseSize")
                         .HasColumnType("int");
 
                     b.Property<string>("ResponseXchangeId")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("RetryBlockedReason")
-                        .HasMaxLength(500)
-                        .HasColumnType("nvarchar(500)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Success")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("Id");
 
@@ -1026,7 +1022,7 @@ namespace SW.Bitween.MsSql.Migrations
             modelBuilder.Entity("SW.Bitween.RunFlagUpdater+RunningResult", b =>
                 {
                     b.Property<bool>("IsRunning")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.ToTable((string)null);
 
@@ -1040,10 +1036,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("bigint")
                         .HasColumnName("id");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
                     b.Property<string>("Context")
-                        .HasColumnType("nvarchar(max)")
+                        .HasColumnType("longtext")
                         .HasColumnName("context");
 
                     b.Property<long?>("DurationMs")
@@ -1051,44 +1047,44 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnName("duration_ms");
 
                     b.Property<DateTime?>("EndTimeUtc")
-                        .HasColumnType("datetime2")
+                        .HasColumnType("datetime(6)")
                         .HasColumnName("end_time_utc");
 
                     b.Property<string>("Error")
-                        .HasColumnType("nvarchar(max)")
+                        .HasColumnType("longtext")
                         .HasColumnName("error");
 
                     b.Property<string>("FireInstanceId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("fire_instance_id");
 
                     b.Property<string>("JobGroup")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_group");
 
                     b.Property<string>("JobName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_name");
 
                     b.Property<string>("JobTypeName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_type_name");
 
                     b.Property<string>("Node")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("node");
 
                     b.Property<DateTime>("StartTimeUtc")
-                        .HasColumnType("datetime2")
+                        .HasColumnType("datetime(6)")
                         .HasColumnName("start_time_utc");
 
                     b.Property<bool?>("Success")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("success");
 
                     b.HasKey("Id");
@@ -1106,88 +1102,88 @@ namespace SW.Bitween.MsSql.Migrations
                     b.HasIndex("JobGroup", "JobName", "StartTimeUtc")
                         .HasDatabaseName("idx_je_group_name_start");
 
-                    b.ToTable("job_executions", "dbo");
+                    b.ToTable("job_executions", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzBlobTrigger", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("TriggerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_name");
 
                     b.Property<string>("TriggerGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.Property<byte[]>("BlobData")
-                        .HasColumnType("varbinary(max)")
+                        .HasColumnType("longblob")
                         .HasColumnName("blob_data");
 
                     b.HasKey("SchedulerName", "TriggerName", "TriggerGroup");
 
-                    b.ToTable("QRTZ_blob_triggers", "dbo");
+                    b.ToTable("QRTZ_blob_triggers", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzCalendar", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("CalendarName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("calendar_name");
 
                     b.Property<byte[]>("Calendar")
                         .IsRequired()
-                        .HasColumnType("varbinary(max)")
+                        .HasColumnType("longblob")
                         .HasColumnName("calendar");
 
                     b.HasKey("SchedulerName", "CalendarName");
 
-                    b.ToTable("QRTZ_calendars", "dbo");
+                    b.ToTable("QRTZ_calendars", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzCronTrigger", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("TriggerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_name");
 
                     b.Property<string>("TriggerGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.Property<string>("CronExpression")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("cron_expression");
 
                     b.Property<string>("TimeZoneId")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("time_zone_id");
 
                     b.HasKey("SchedulerName", "TriggerName", "TriggerGroup");
 
-                    b.ToTable("QRTZ_cron_triggers", "dbo");
+                    b.ToTable("QRTZ_cron_triggers", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzFiredTrigger", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("EntryId")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("entry_id");
 
                     b.Property<long>("FiredTime")
@@ -1196,19 +1192,19 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("InstanceName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("instance_name");
 
                     b.Property<bool>("IsNonConcurrent")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("is_nonconcurrent");
 
                     b.Property<string>("JobGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_group");
 
                     b.Property<string>("JobName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_name");
 
                     b.Property<int>("Priority")
@@ -1216,7 +1212,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnName("priority");
 
                     b.Property<bool?>("RequestsRecovery")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("requests_recovery");
 
                     b.Property<long>("ScheduledTime")
@@ -1225,17 +1221,17 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("State")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("state");
 
                     b.Property<string>("TriggerGroup")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.Property<string>("TriggerName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_name");
 
                     b.HasKey("SchedulerName", "EntryId");
@@ -1261,50 +1257,50 @@ namespace SW.Bitween.MsSql.Migrations
                     b.HasIndex("SchedulerName", "TriggerName", "TriggerGroup")
                         .HasDatabaseName("idx_QRTZ_ft_trig_nm_gp");
 
-                    b.ToTable("QRTZ_fired_triggers", "dbo");
+                    b.ToTable("QRTZ_fired_triggers", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzJobDetail", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("JobName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_name");
 
                     b.Property<string>("JobGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_group");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("description");
 
                     b.Property<bool>("IsDurable")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("is_durable");
 
                     b.Property<bool>("IsNonConcurrent")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("is_nonconcurrent");
 
                     b.Property<bool>("IsUpdateData")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("is_update_data");
 
                     b.Property<string>("JobClassName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_class_name");
 
                     b.Property<byte[]>("JobData")
-                        .HasColumnType("varbinary(max)")
+                        .HasColumnType("longblob")
                         .HasColumnName("job_data");
 
                     b.Property<bool>("RequestsRecovery")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("requests_recovery");
 
                     b.HasKey("SchedulerName", "JobName", "JobGroup");
@@ -1312,47 +1308,47 @@ namespace SW.Bitween.MsSql.Migrations
                     b.HasIndex("RequestsRecovery")
                         .HasDatabaseName("idx_j_req_recovery");
 
-                    b.ToTable("QRTZ_job_details", "dbo");
+                    b.ToTable("QRTZ_job_details", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzLock", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("LockName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("lock_name");
 
                     b.HasKey("SchedulerName", "LockName");
 
-                    b.ToTable("QRTZ_locks", "dbo");
+                    b.ToTable("QRTZ_locks", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzPausedTriggerGroup", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("TriggerGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.HasKey("SchedulerName", "TriggerGroup");
 
-                    b.ToTable("QRTZ_paused_trigger_grps", "dbo");
+                    b.ToTable("QRTZ_paused_trigger_grps", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzSchedulerState", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("InstanceName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("instance_name");
 
                     b.Property<long>("CheckInInterval")
@@ -1365,29 +1361,29 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.HasKey("SchedulerName", "InstanceName");
 
-                    b.ToTable("QRTZ_scheduler_state", "dbo");
+                    b.ToTable("QRTZ_scheduler_state", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzSimplePropertyTrigger", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("TriggerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_name");
 
                     b.Property<string>("TriggerGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.Property<bool?>("BooleanProperty1")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("bool_prop_1");
 
                     b.Property<bool?>("BooleanProperty2")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("bool_prop_2");
 
                     b.Property<decimal?>("DecimalProperty1")
@@ -1415,38 +1411,38 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnName("long_prop_2");
 
                     b.Property<string>("StringProperty1")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("str_prop_1");
 
                     b.Property<string>("StringProperty2")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("str_prop_2");
 
                     b.Property<string>("StringProperty3")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("str_prop_3");
 
                     b.Property<string>("TimeZoneId")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("time_zone_id");
 
                     b.HasKey("SchedulerName", "TriggerName", "TriggerGroup");
 
-                    b.ToTable("QRTZ_simprop_triggers", "dbo");
+                    b.ToTable("QRTZ_simprop_triggers", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzSimpleTrigger", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("TriggerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_name");
 
                     b.Property<string>("TriggerGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.Property<long>("RepeatCount")
@@ -1463,29 +1459,29 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.HasKey("SchedulerName", "TriggerName", "TriggerGroup");
 
-                    b.ToTable("QRTZ_simple_triggers", "dbo");
+                    b.ToTable("QRTZ_simple_triggers", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzTrigger", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("TriggerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_name");
 
                     b.Property<string>("TriggerGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.Property<string>("CalendarName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("calendar_name");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("description");
 
                     b.Property<long?>("EndTime")
@@ -1493,17 +1489,17 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnName("end_time");
 
                     b.Property<byte[]>("JobData")
-                        .HasColumnType("varbinary(max)")
+                        .HasColumnType("longblob")
                         .HasColumnName("job_data");
 
                     b.Property<string>("JobGroup")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_group");
 
                     b.Property<string>("JobName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_name");
 
                     b.Property<int?>("MisfireInstruction")
@@ -1528,12 +1524,12 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("TriggerState")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_state");
 
                     b.Property<string>("TriggerType")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_type");
 
                     b.HasKey("SchedulerName", "TriggerName", "TriggerGroup");
@@ -1549,7 +1545,7 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.HasIndex("SchedulerName", "JobName", "JobGroup");
 
-                    b.ToTable("QRTZ_triggers", "dbo");
+                    b.ToTable("QRTZ_triggers", (string)null);
                 });
 
             modelBuilder.Entity("SW.Bitween.Domain.Accounts.RefreshToken", b =>
@@ -1645,7 +1641,7 @@ namespace SW.Bitween.MsSql.Migrations
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType("int");
 
-                            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b1.Property<int>("Id"));
+                            MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b1.Property<int>("Id"));
 
                             b1.Property<string>("Key")
                                 .IsRequired()
@@ -1656,7 +1652,7 @@ namespace SW.Bitween.MsSql.Migrations
                             b1.Property<string>("Name")
                                 .IsRequired()
                                 .HasMaxLength(500)
-                                .HasColumnType("nvarchar(500)");
+                                .HasColumnType("varchar(500)");
 
                             b1.HasKey("PartnerId", "Id");
 
@@ -1728,16 +1724,16 @@ namespace SW.Bitween.MsSql.Migrations
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType("int");
 
-                            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b1.Property<int>("Id"));
+                            MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b1.Property<int>("Id"));
 
                             b1.Property<bool>("Backwards")
-                                .HasColumnType("bit");
+                                .HasColumnType("tinyint(1)");
 
                             b1.Property<long>("On")
                                 .HasColumnType("bigint");
 
                             b1.Property<byte>("Recurrence")
-                                .HasColumnType("tinyint");
+                                .HasColumnType("tinyint unsigned");
 
                             b1.HasKey("SubscriptionId", "Id");
 

--- a/SW.Bitween.MySql/Migrations/20260811081221_SharedRetryGroupTotals.cs
+++ b/SW.Bitween.MySql/Migrations/20260811081221_SharedRetryGroupTotals.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SW.Bitween.MySql.Migrations
+{
+    /// <inheritdoc />
+    public partial class SharedRetryGroupTotals : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GroupAttemptCounts",
+                table: "Xchanges");
+
+            migrationBuilder.DropColumn(
+                name: "GroupAttemptCounts",
+                table: "DelayedRetries");
+
+            migrationBuilder.CreateTable(
+                name: "RetryGroupUsages",
+                columns: table => new
+                {
+                    SubscriptionId = table.Column<int>(type: "int", nullable: false),
+                    GroupId = table.Column<Guid>(type: "char(36)", nullable: false, collation: "ascii_general_ci"),
+                    AttemptsUsed = table.Column<int>(type: "int", nullable: false),
+                    LastAttemptOn = table.Column<DateTime>(type: "datetime(6)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RetryGroupUsages", x => new { x.SubscriptionId, x.GroupId });
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "RetryGroupUsages");
+
+            migrationBuilder.AddColumn<string>(
+                name: "GroupAttemptCounts",
+                table: "Xchanges",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<string>(
+                name: "GroupAttemptCounts",
+                table: "DelayedRetries",
+                type: "longtext",
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/SW.Bitween.MySql/Migrations/20260811092323_RetryBlockedReason.Designer.cs
+++ b/SW.Bitween.MySql/Migrations/20260811092323_RetryBlockedReason.Designer.cs
@@ -3,24 +3,27 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using SW.Bitween.MsSql;
+using SW.Bitween.MySql;
 
 #nullable disable
 
-namespace SW.Bitween.MsSql.Migrations
+namespace SW.Bitween.MySql.Migrations
 {
     [DbContext(typeof(BitweenDbContext))]
-    partial class BitweenDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811092323_RetryBlockedReason")]
+    partial class RetryBlockedReason
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "8.0.23")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            MySqlModelBuilderExtensions.AutoIncrementColumns(modelBuilder);
 
             modelBuilder.Entity("SW.Bitween.Domain.Accounts.Account", b =>
                 {
@@ -28,24 +31,24 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool>("Deleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("Disabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("DisplayName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<string>("Email")
                         .HasMaxLength(200)
@@ -53,16 +56,16 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<byte>("EmailProvider")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<byte>("LoginMethods")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Password")
                         .HasMaxLength(500)
@@ -80,8 +83,7 @@ namespace SW.Bitween.MsSql.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("Email")
-                        .IsUnique()
-                        .HasFilter("[Email] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("Accounts", (string)null);
 
@@ -112,10 +114,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<byte>("LoginMethod")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.HasKey("Id");
 
@@ -132,7 +134,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<DateTime>("On")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("Id");
 
@@ -147,7 +149,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<bool>("BusEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("BusMessageTypeName")
                         .HasMaxLength(500)
@@ -155,7 +157,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(500)");
 
                     b.Property<bool?>("DisregardsUnfilteredMessages")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("DocumentFormat")
                         .HasColumnType("int");
@@ -170,13 +172,12 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(100)");
 
                     b.Property<string>("PromotedProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
                     b.HasIndex("BusMessageTypeName")
-                        .IsUnique()
-                        .HasFilter("[BusMessageTypeName] IS NOT NULL");
+                        .IsUnique();
 
                     b.HasIndex("Name")
                         .IsUnique();
@@ -199,25 +200,25 @@ namespace SW.Bitween.MsSql.Migrations
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<int>("Code")
                         .HasColumnType("int");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("DocumentId")
                         .HasColumnType("int");
 
                     b.Property<string>("StateAfter")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("StateBefore")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -234,29 +235,29 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<string>("UrlName")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.HasKey("Id");
 
@@ -278,16 +279,16 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("ApiGatewayId", "PartnerId", "SubscriptionId");
 
@@ -304,27 +305,27 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("DocumentId")
                         .HasColumnType("int");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.HasKey("Id");
 
@@ -339,25 +340,25 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<int>("BusGatewayId")
                         .HasColumnType("int");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("MatchExpression")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int?>("PartnerId")
                         .HasColumnType("int");
@@ -384,10 +385,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Values")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -400,7 +401,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("HandlerId")
                         .HasMaxLength(200)
@@ -408,27 +409,27 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("HandlerProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Inactive")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("varchar(100)");
 
                     b.Property<bool>("RunOnBadResult")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("RunOnFailedResult")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("RunOnSubscriptions")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("RunOnSuccessfulResult")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("Id");
 
@@ -441,20 +442,20 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<bool>("BadData")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("FileName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("References")
                         .HasMaxLength(1024)
-                        .HasColumnType("nvarchar(1024)");
+                        .HasColumnType("varchar(1024)");
 
                     b.Property<int>("SubscriptionId")
                         .HasColumnType("int");
@@ -472,10 +473,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("AdapterProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
                         .IsRequired()
@@ -501,13 +502,13 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<Guid>("GroupId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("char(36)");
 
                     b.Property<int>("AttemptsUsed")
                         .HasColumnType("int");
 
                     b.Property<DateTime>("LastAttemptOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("SubscriptionId", "GroupId");
 
@@ -520,27 +521,27 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Groups")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.HasKey("Id");
 
@@ -553,16 +554,16 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<DateTime?>("AggregateOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int?>("AggregationForId")
                         .HasColumnType("int");
 
                     b.Property<byte>("AggregationTarget")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<int?>("CategoryId")
                         .HasColumnType("int");
@@ -571,10 +572,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<string>("CustomRetryPolicy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("DocumentFilter")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("DocumentId")
                         .HasColumnType("int");
@@ -585,16 +586,16 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("HandlerProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Inactive")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsRunning")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("LastException")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("MapperId")
                         .HasMaxLength(200)
@@ -602,24 +603,24 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("MapperProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("MatchExpression")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("varchar(100)");
 
                     b.Property<int?>("PartnerId")
                         .HasColumnType("int");
 
                     b.Property<DateTime?>("PausedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime?>("ReceiveOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ReceiverId")
                         .HasMaxLength(200)
@@ -627,7 +628,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("ReceiverProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ResponseMessageTypeName")
                         .HasMaxLength(500)
@@ -641,10 +642,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("int");
 
                     b.Property<bool>("Temporary")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<byte>("Type")
-                        .HasColumnType("tinyint");
+                        .HasColumnType("tinyint unsigned");
 
                     b.Property<string>("ValidatorId")
                         .HasMaxLength(200)
@@ -652,7 +653,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("ValidatorProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int?>("WorkGroupId")
                         .HasColumnType("int");
@@ -682,31 +683,30 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Code")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ModifiedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime?>("ModifiedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("Code")
-                        .IsUnique()
-                        .HasFilter("[Code] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("SubscriptionCategory");
                 });
@@ -715,22 +715,22 @@ namespace SW.Bitween.MsSql.Migrations
                 {
                     b.Property<string>("Id")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<int>("Code")
                         .HasColumnType("int");
 
                     b.Property<string>("CreatedBy")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("CreatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("StateAfter")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("StateBefore")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("SubscriptionId")
                         .HasColumnType("int");
@@ -750,7 +750,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("BusMessageName")
                         .IsRequired()
@@ -759,10 +759,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(100)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("Options")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -777,7 +777,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<string>("CorrelationId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int>("DocumentId")
                         .HasColumnType("int");
@@ -788,7 +788,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("HandlerProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("InputContentType")
                         .HasMaxLength(200)
@@ -803,7 +803,7 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("InputName")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<int>("InputSize")
                         .HasColumnType("int");
@@ -814,14 +814,14 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(200)");
 
                     b.Property<string>("MapperProperties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<int?>("PartnerId")
                         .HasColumnType("int");
 
                     b.Property<string>("References")
                         .HasMaxLength(1024)
-                        .HasColumnType("nvarchar(1024)");
+                        .HasColumnType("varchar(1024)");
 
                     b.Property<string>("ResponseMessageTypeName")
                         .HasMaxLength(500)
@@ -837,7 +837,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<DateTime>("StartedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int?>("SubscriptionId")
                         .HasColumnType("int");
@@ -865,7 +865,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<DateTime>("AggregatedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("AggregationXchangeId")
                         .IsRequired()
@@ -888,7 +888,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<DateTime>("DeliveredOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.HasKey("Id");
 
@@ -903,22 +903,22 @@ namespace SW.Bitween.MsSql.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("Exception")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("FinishedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<int>("NotifierId")
                         .HasColumnType("int");
 
                     b.Property<string>("NotifierName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<bool>("Success")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("XchangeId")
                         .HasMaxLength(50)
@@ -943,10 +943,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(2000)");
 
                     b.Property<string>("Properties")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("PropertiesRaw")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("varchar(255)");
 
                     b.HasKey("Id");
 
@@ -963,13 +963,13 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("varchar(50)");
 
                     b.Property<string>("Exception")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<DateTime>("FinishedOn")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<bool>("OutputBad")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("OutputContentType")
                         .HasMaxLength(200)
@@ -983,13 +983,13 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("OutputName")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<int>("OutputSize")
                         .HasColumnType("int");
 
                     b.Property<bool>("ResponseBad")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("ResponseContentType")
                         .HasMaxLength(200)
@@ -1003,20 +1003,20 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("ResponseName")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<int>("ResponseSize")
                         .HasColumnType("int");
 
                     b.Property<string>("ResponseXchangeId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("RetryBlockedReason")
                         .HasMaxLength(500)
-                        .HasColumnType("nvarchar(500)");
+                        .HasColumnType("varchar(500)");
 
                     b.Property<bool>("Success")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.HasKey("Id");
 
@@ -1026,7 +1026,7 @@ namespace SW.Bitween.MsSql.Migrations
             modelBuilder.Entity("SW.Bitween.RunFlagUpdater+RunningResult", b =>
                 {
                     b.Property<bool>("IsRunning")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.ToTable((string)null);
 
@@ -1040,10 +1040,10 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnType("bigint")
                         .HasColumnName("id");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<long>("Id"));
+                    MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b.Property<long>("Id"));
 
                     b.Property<string>("Context")
-                        .HasColumnType("nvarchar(max)")
+                        .HasColumnType("longtext")
                         .HasColumnName("context");
 
                     b.Property<long?>("DurationMs")
@@ -1051,44 +1051,44 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnName("duration_ms");
 
                     b.Property<DateTime?>("EndTimeUtc")
-                        .HasColumnType("datetime2")
+                        .HasColumnType("datetime(6)")
                         .HasColumnName("end_time_utc");
 
                     b.Property<string>("Error")
-                        .HasColumnType("nvarchar(max)")
+                        .HasColumnType("longtext")
                         .HasColumnName("error");
 
                     b.Property<string>("FireInstanceId")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("fire_instance_id");
 
                     b.Property<string>("JobGroup")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_group");
 
                     b.Property<string>("JobName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_name");
 
                     b.Property<string>("JobTypeName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_type_name");
 
                     b.Property<string>("Node")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("node");
 
                     b.Property<DateTime>("StartTimeUtc")
-                        .HasColumnType("datetime2")
+                        .HasColumnType("datetime(6)")
                         .HasColumnName("start_time_utc");
 
                     b.Property<bool?>("Success")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("success");
 
                     b.HasKey("Id");
@@ -1106,88 +1106,88 @@ namespace SW.Bitween.MsSql.Migrations
                     b.HasIndex("JobGroup", "JobName", "StartTimeUtc")
                         .HasDatabaseName("idx_je_group_name_start");
 
-                    b.ToTable("job_executions", "dbo");
+                    b.ToTable("job_executions", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzBlobTrigger", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("TriggerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_name");
 
                     b.Property<string>("TriggerGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.Property<byte[]>("BlobData")
-                        .HasColumnType("varbinary(max)")
+                        .HasColumnType("longblob")
                         .HasColumnName("blob_data");
 
                     b.HasKey("SchedulerName", "TriggerName", "TriggerGroup");
 
-                    b.ToTable("QRTZ_blob_triggers", "dbo");
+                    b.ToTable("QRTZ_blob_triggers", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzCalendar", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("CalendarName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("calendar_name");
 
                     b.Property<byte[]>("Calendar")
                         .IsRequired()
-                        .HasColumnType("varbinary(max)")
+                        .HasColumnType("longblob")
                         .HasColumnName("calendar");
 
                     b.HasKey("SchedulerName", "CalendarName");
 
-                    b.ToTable("QRTZ_calendars", "dbo");
+                    b.ToTable("QRTZ_calendars", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzCronTrigger", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("TriggerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_name");
 
                     b.Property<string>("TriggerGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.Property<string>("CronExpression")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("cron_expression");
 
                     b.Property<string>("TimeZoneId")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("time_zone_id");
 
                     b.HasKey("SchedulerName", "TriggerName", "TriggerGroup");
 
-                    b.ToTable("QRTZ_cron_triggers", "dbo");
+                    b.ToTable("QRTZ_cron_triggers", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzFiredTrigger", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("EntryId")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("entry_id");
 
                     b.Property<long>("FiredTime")
@@ -1196,19 +1196,19 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("InstanceName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("instance_name");
 
                     b.Property<bool>("IsNonConcurrent")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("is_nonconcurrent");
 
                     b.Property<string>("JobGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_group");
 
                     b.Property<string>("JobName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_name");
 
                     b.Property<int>("Priority")
@@ -1216,7 +1216,7 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnName("priority");
 
                     b.Property<bool?>("RequestsRecovery")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("requests_recovery");
 
                     b.Property<long>("ScheduledTime")
@@ -1225,17 +1225,17 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("State")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("state");
 
                     b.Property<string>("TriggerGroup")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.Property<string>("TriggerName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_name");
 
                     b.HasKey("SchedulerName", "EntryId");
@@ -1261,50 +1261,50 @@ namespace SW.Bitween.MsSql.Migrations
                     b.HasIndex("SchedulerName", "TriggerName", "TriggerGroup")
                         .HasDatabaseName("idx_QRTZ_ft_trig_nm_gp");
 
-                    b.ToTable("QRTZ_fired_triggers", "dbo");
+                    b.ToTable("QRTZ_fired_triggers", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzJobDetail", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("JobName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_name");
 
                     b.Property<string>("JobGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_group");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("description");
 
                     b.Property<bool>("IsDurable")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("is_durable");
 
                     b.Property<bool>("IsNonConcurrent")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("is_nonconcurrent");
 
                     b.Property<bool>("IsUpdateData")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("is_update_data");
 
                     b.Property<string>("JobClassName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_class_name");
 
                     b.Property<byte[]>("JobData")
-                        .HasColumnType("varbinary(max)")
+                        .HasColumnType("longblob")
                         .HasColumnName("job_data");
 
                     b.Property<bool>("RequestsRecovery")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("requests_recovery");
 
                     b.HasKey("SchedulerName", "JobName", "JobGroup");
@@ -1312,47 +1312,47 @@ namespace SW.Bitween.MsSql.Migrations
                     b.HasIndex("RequestsRecovery")
                         .HasDatabaseName("idx_j_req_recovery");
 
-                    b.ToTable("QRTZ_job_details", "dbo");
+                    b.ToTable("QRTZ_job_details", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzLock", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("LockName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("lock_name");
 
                     b.HasKey("SchedulerName", "LockName");
 
-                    b.ToTable("QRTZ_locks", "dbo");
+                    b.ToTable("QRTZ_locks", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzPausedTriggerGroup", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("TriggerGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.HasKey("SchedulerName", "TriggerGroup");
 
-                    b.ToTable("QRTZ_paused_trigger_grps", "dbo");
+                    b.ToTable("QRTZ_paused_trigger_grps", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzSchedulerState", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("InstanceName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("instance_name");
 
                     b.Property<long>("CheckInInterval")
@@ -1365,29 +1365,29 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.HasKey("SchedulerName", "InstanceName");
 
-                    b.ToTable("QRTZ_scheduler_state", "dbo");
+                    b.ToTable("QRTZ_scheduler_state", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzSimplePropertyTrigger", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("TriggerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_name");
 
                     b.Property<string>("TriggerGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.Property<bool?>("BooleanProperty1")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("bool_prop_1");
 
                     b.Property<bool?>("BooleanProperty2")
-                        .HasColumnType("bit")
+                        .HasColumnType("tinyint(1)")
                         .HasColumnName("bool_prop_2");
 
                     b.Property<decimal?>("DecimalProperty1")
@@ -1415,38 +1415,38 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnName("long_prop_2");
 
                     b.Property<string>("StringProperty1")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("str_prop_1");
 
                     b.Property<string>("StringProperty2")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("str_prop_2");
 
                     b.Property<string>("StringProperty3")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("str_prop_3");
 
                     b.Property<string>("TimeZoneId")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("time_zone_id");
 
                     b.HasKey("SchedulerName", "TriggerName", "TriggerGroup");
 
-                    b.ToTable("QRTZ_simprop_triggers", "dbo");
+                    b.ToTable("QRTZ_simprop_triggers", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzSimpleTrigger", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("TriggerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_name");
 
                     b.Property<string>("TriggerGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.Property<long>("RepeatCount")
@@ -1463,29 +1463,29 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.HasKey("SchedulerName", "TriggerName", "TriggerGroup");
 
-                    b.ToTable("QRTZ_simple_triggers", "dbo");
+                    b.ToTable("QRTZ_simple_triggers", (string)null);
                 });
 
             modelBuilder.Entity("SW.Scheduler.QuartzTrigger", b =>
                 {
                     b.Property<string>("SchedulerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("sched_name");
 
                     b.Property<string>("TriggerName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_name");
 
                     b.Property<string>("TriggerGroup")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_group");
 
                     b.Property<string>("CalendarName")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("calendar_name");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("description");
 
                     b.Property<long?>("EndTime")
@@ -1493,17 +1493,17 @@ namespace SW.Bitween.MsSql.Migrations
                         .HasColumnName("end_time");
 
                     b.Property<byte[]>("JobData")
-                        .HasColumnType("varbinary(max)")
+                        .HasColumnType("longblob")
                         .HasColumnName("job_data");
 
                     b.Property<string>("JobGroup")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_group");
 
                     b.Property<string>("JobName")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("job_name");
 
                     b.Property<int?>("MisfireInstruction")
@@ -1528,12 +1528,12 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.Property<string>("TriggerState")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_state");
 
                     b.Property<string>("TriggerType")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)")
+                        .HasColumnType("varchar(200)")
                         .HasColumnName("trigger_type");
 
                     b.HasKey("SchedulerName", "TriggerName", "TriggerGroup");
@@ -1549,7 +1549,7 @@ namespace SW.Bitween.MsSql.Migrations
 
                     b.HasIndex("SchedulerName", "JobName", "JobGroup");
 
-                    b.ToTable("QRTZ_triggers", "dbo");
+                    b.ToTable("QRTZ_triggers", (string)null);
                 });
 
             modelBuilder.Entity("SW.Bitween.Domain.Accounts.RefreshToken", b =>
@@ -1645,7 +1645,7 @@ namespace SW.Bitween.MsSql.Migrations
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType("int");
 
-                            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b1.Property<int>("Id"));
+                            MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b1.Property<int>("Id"));
 
                             b1.Property<string>("Key")
                                 .IsRequired()
@@ -1656,7 +1656,7 @@ namespace SW.Bitween.MsSql.Migrations
                             b1.Property<string>("Name")
                                 .IsRequired()
                                 .HasMaxLength(500)
-                                .HasColumnType("nvarchar(500)");
+                                .HasColumnType("varchar(500)");
 
                             b1.HasKey("PartnerId", "Id");
 
@@ -1728,16 +1728,16 @@ namespace SW.Bitween.MsSql.Migrations
                                 .ValueGeneratedOnAdd()
                                 .HasColumnType("int");
 
-                            SqlServerPropertyBuilderExtensions.UseIdentityColumn(b1.Property<int>("Id"));
+                            MySqlPropertyBuilderExtensions.UseMySqlIdentityColumn(b1.Property<int>("Id"));
 
                             b1.Property<bool>("Backwards")
-                                .HasColumnType("bit");
+                                .HasColumnType("tinyint(1)");
 
                             b1.Property<long>("On")
                                 .HasColumnType("bigint");
 
                             b1.Property<byte>("Recurrence")
-                                .HasColumnType("tinyint");
+                                .HasColumnType("tinyint unsigned");
 
                             b1.HasKey("SubscriptionId", "Id");
 

--- a/SW.Bitween.MySql/Migrations/20260811092323_RetryBlockedReason.cs
+++ b/SW.Bitween.MySql/Migrations/20260811092323_RetryBlockedReason.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SW.Bitween.MySql.Migrations
+{
+    /// <inheritdoc />
+    public partial class RetryBlockedReason : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "RetryBlockedReason",
+                table: "XchangeResults",
+                type: "varchar(500)",
+                maxLength: 500,
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RetryBlockedReason",
+                table: "XchangeResults");
+        }
+    }
+}

--- a/SW.Bitween.MySql/Migrations/BitweenDbContextModelSnapshot.cs
+++ b/SW.Bitween.MySql/Migrations/BitweenDbContextModelSnapshot.cs
@@ -130,9 +130,6 @@ namespace SW.Bitween.MySql.Migrations
                         .IsUnicode(false)
                         .HasColumnType("varchar(50)");
 
-                    b.Property<string>("GroupAttemptCounts")
-                        .HasColumnType("longtext");
-
                     b.Property<DateTime>("On")
                         .HasColumnType("datetime(6)");
 
@@ -496,6 +493,25 @@ namespace SW.Bitween.MySql.Migrations
                         });
                 });
 
+            modelBuilder.Entity("SW.Bitween.Domain.RetryGroupUsage", b =>
+                {
+                    b.Property<int>("SubscriptionId")
+                        .HasColumnType("int");
+
+                    b.Property<Guid>("GroupId")
+                        .HasColumnType("char(36)");
+
+                    b.Property<int>("AttemptsUsed")
+                        .HasColumnType("int");
+
+                    b.Property<DateTime>("LastAttemptOn")
+                        .HasColumnType("datetime(6)");
+
+                    b.HasKey("SubscriptionId", "GroupId");
+
+                    b.ToTable("RetryGroupUsages", (string)null);
+                });
+
             modelBuilder.Entity("SW.Bitween.Domain.RetryPolicy", b =>
                 {
                     b.Property<int>("Id")
@@ -763,9 +779,6 @@ namespace SW.Bitween.MySql.Migrations
                     b.Property<int>("DocumentId")
                         .HasColumnType("int");
 
-                    b.Property<string>("GroupAttemptCounts")
-                        .HasColumnType("longtext");
-
                     b.Property<string>("HandlerId")
                         .HasMaxLength(200)
                         .IsUnicode(false)
@@ -994,6 +1007,10 @@ namespace SW.Bitween.MySql.Migrations
 
                     b.Property<string>("ResponseXchangeId")
                         .HasColumnType("longtext");
+
+                    b.Property<string>("RetryBlockedReason")
+                        .HasMaxLength(500)
+                        .HasColumnType("varchar(500)");
 
                     b.Property<bool>("Success")
                         .HasColumnType("tinyint(1)");

--- a/SW.Bitween.PgSql/BitweenDbContext.cs
+++ b/SW.Bitween.PgSql/BitweenDbContext.cs
@@ -262,6 +262,7 @@ namespace SW.Bitween.PgSql
                 b.Property(p => p.ResponseName).HasMaxLength(200);
                 b.Property(p => p.ResponseContentType).HasMaxLength(200);
                 b.Property(p => p.OutputContentType).HasMaxLength(200);
+                b.Property(p => p.RetryBlockedReason).HasMaxLength(500);
 
                 b.HasOne<Xchange>().WithOne().HasForeignKey<XchangeResult>(p => p.Id).OnDelete(DeleteBehavior.Cascade);
             });
@@ -384,13 +385,14 @@ namespace SW.Bitween.PgSql
             {
                 b.HasKey(p => p.Id);
                 b.Property(p => p.Id).HasMaxLength(50);
-                b.Property(p => p.GroupAttemptCounts).HasColumnType("jsonb");
                 b.HasIndex(p => p.On);
             });
 
-            modelBuilder.Entity<Xchange>(b =>
+            modelBuilder.Entity<RetryGroupUsage>(b =>
             {
-                b.Property(p => p.GroupAttemptCounts).HasColumnType("jsonb");
+                b.HasKey(p => new { p.SubscriptionId, p.GroupId });
+                b.Property(p => p.AttemptsUsed);
+                b.Property(p => p.LastAttemptOn);
             });
 
             modelBuilder.UseSchedulerPostgreSql(Schema);

--- a/SW.Bitween.PgSql/Migrations/20260811081200_SharedRetryGroupTotals.Designer.cs
+++ b/SW.Bitween.PgSql/Migrations/20260811081200_SharedRetryGroupTotals.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SW.Bitween.Model;
@@ -13,9 +14,11 @@ using SW.Bitween.PgSql;
 namespace SW.Bitween.PgSql.Migrations
 {
     [DbContext(typeof(BitweenDbContext))]
-    partial class BitweenDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811081200_SharedRetryGroupTotals")]
+    partial class SharedRetryGroupTotals
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1229,11 +1232,6 @@ namespace SW.Bitween.PgSql.Migrations
                     b.Property<string>("ResponseXchangeId")
                         .HasColumnType("text")
                         .HasColumnName("response_xchange_id");
-
-                    b.Property<string>("RetryBlockedReason")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)")
-                        .HasColumnName("retry_blocked_reason");
 
                     b.Property<bool>("Success")
                         .HasColumnType("boolean")

--- a/SW.Bitween.PgSql/Migrations/20260811081200_SharedRetryGroupTotals.cs
+++ b/SW.Bitween.PgSql/Migrations/20260811081200_SharedRetryGroupTotals.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SW.Bitween.PgSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class SharedRetryGroupTotals : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "group_attempt_counts",
+                schema: "infolink",
+                table: "xchange");
+
+            migrationBuilder.DropColumn(
+                name: "group_attempt_counts",
+                schema: "infolink",
+                table: "delayed_retry");
+
+            migrationBuilder.CreateTable(
+                name: "retry_group_usage",
+                schema: "infolink",
+                columns: table => new
+                {
+                    subscription_id = table.Column<int>(type: "integer", nullable: false),
+                    group_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    attempts_used = table.Column<int>(type: "integer", nullable: false),
+                    last_attempt_on = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_retry_group_usage", x => new { x.subscription_id, x.group_id });
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "retry_group_usage",
+                schema: "infolink");
+
+            migrationBuilder.AddColumn<Dictionary<string, int>>(
+                name: "group_attempt_counts",
+                schema: "infolink",
+                table: "xchange",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Dictionary<string, int>>(
+                name: "group_attempt_counts",
+                schema: "infolink",
+                table: "delayed_retry",
+                type: "jsonb",
+                nullable: true);
+        }
+    }
+}

--- a/SW.Bitween.PgSql/Migrations/20260811092318_RetryBlockedReason.Designer.cs
+++ b/SW.Bitween.PgSql/Migrations/20260811092318_RetryBlockedReason.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SW.Bitween.Model;
@@ -13,9 +14,11 @@ using SW.Bitween.PgSql;
 namespace SW.Bitween.PgSql.Migrations
 {
     [DbContext(typeof(BitweenDbContext))]
-    partial class BitweenDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811092318_RetryBlockedReason")]
+    partial class RetryBlockedReason
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SW.Bitween.PgSql/Migrations/20260811092318_RetryBlockedReason.cs
+++ b/SW.Bitween.PgSql/Migrations/20260811092318_RetryBlockedReason.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SW.Bitween.PgSql.Migrations
+{
+    /// <inheritdoc />
+    public partial class RetryBlockedReason : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "retry_blocked_reason",
+                schema: "infolink",
+                table: "xchange_result",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "retry_blocked_reason",
+                schema: "infolink",
+                table: "xchange_result");
+        }
+    }
+}

--- a/SW.Bitween.Sdk/Model/AutoRetry/IRetryGroupBudget.cs
+++ b/SW.Bitween.Sdk/Model/AutoRetry/IRetryGroupBudget.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SW.Bitween.Model;
+
+/// <summary>
+/// Tracks how much of a <see cref="RetryGroup"/>'s <see cref="RetryBudget.MaxAttemptsTotal"/>
+/// has already been spent.
+/// </summary>
+/// <remarks>
+/// The total is a ceiling shared by every message that hits the group, so the count cannot
+/// live on the message being evaluated — it needs a store that outlives a single xchange.
+/// The implementation decides the scope: the production one keys by integration + group and
+/// persists, while <see cref="InMemoryRetryGroupBudget"/> counts only for one dry-run.
+/// </remarks>
+public interface IRetryGroupBudget
+{
+    /// <summary>Claims one attempt from the group's total budget.</summary>
+    /// <returns>
+    /// <c>true</c> when a slot was claimed; <c>false</c> when the total is already spent
+    /// and no further retry may be scheduled for this group.
+    /// </returns>
+    Task<bool> TryConsume(Guid groupId, int maxAttemptsTotal);
+}
+
+/// <summary>
+/// In-memory <see cref="IRetryGroupBudget"/> for the policy dry-run endpoint, where nothing
+/// should be persisted and the budget spans only the simulated run.
+/// </summary>
+public class InMemoryRetryGroupBudget : IRetryGroupBudget
+{
+    private readonly Dictionary<Guid, int> _used = new();
+
+    /// <inheritdoc/>
+    public Task<bool> TryConsume(Guid groupId, int maxAttemptsTotal)
+    {
+        var used = _used.GetValueOrDefault(groupId, 0);
+        if (used >= maxAttemptsTotal) return Task.FromResult(false);
+
+        _used[groupId] = used + 1;
+        return Task.FromResult(true);
+    }
+}

--- a/SW.Bitween.Sdk/Model/AutoRetry/RetryPolicyEvaluator.cs
+++ b/SW.Bitween.Sdk/Model/AutoRetry/RetryPolicyEvaluator.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace SW.Bitween.Model;
 
@@ -10,47 +10,18 @@ namespace SW.Bitween.Model;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <strong>Stateful per processing window.</strong>  The evaluator accumulates
-/// per-group attempt totals in <c>_groupAttemptCounts</c>.  For a single in-process
-/// window (e.g. a running <c>RetryJob</c> batch) one instance handles all messages.
+/// <strong>Two independent caps.</strong>  <see cref="RetryBudget.MaxAttemptsPerError"/> is
+/// per message and is derived from the caller's <c>attemptIndexForThisMessage</c>, while
+/// <see cref="RetryBudget.MaxAttemptsTotal"/> is shared by every message hitting the group and
+/// is owned by the injected <see cref="IRetryGroupBudget"/>.  The evaluator itself keeps no
+/// counters, so a fresh instance per failure enforces both caps correctly.
 /// </para>
 /// <para>
-/// <strong>Cross-invocation persistence.</strong>  When a retry is scheduled the
-/// current counts are saved to <see cref="GetGroupAttemptCounts"/> and stored on
-/// the <c>DelayedRetry</c> entity (and on the new <c>Xchange</c> so that a later
-/// failure of the retry itself can pick up where the budgets left off).  On the next
-/// evaluation call <see cref="RestoreGroupAttemptCounts"/> before <see cref="Evaluate"/>.
-/// </para>
-/// <para>
-/// <strong>Not thread-safe.</strong>  Each goroutine/task should use its own instance.
+/// <strong>Not thread-safe.</strong>  Each task should use its own instance.
 /// </para>
 /// </remarks>
-public class RetryPolicyEvaluator(IRetryPolicy policy)
+public class RetryPolicyEvaluator(IRetryPolicy policy, IRetryGroupBudget groupBudget)
 {
-    private readonly Dictionary<Guid, int> _groupAttemptCounts = new();
-
-    /// <summary>
-    /// Restores previously persisted group-level attempt counts, allowing budgets
-    /// to continue from where they left off across separate process invocations.
-    /// </summary>
-    /// <param name="counts">
-    /// The dictionary returned by <see cref="GetGroupAttemptCounts"/> from a prior evaluation.
-    /// String keys are parsed back to <see cref="Guid"/> — invalid entries are silently ignored.
-    /// </param>
-    public void RestoreGroupAttemptCounts(Dictionary<string, int> counts)
-    {
-        foreach (var kv in counts)
-            if (Guid.TryParse(kv.Key, out var guid))
-                _groupAttemptCounts[guid] = kv.Value;
-    }
-
-    /// <summary>
-    /// Returns the current group-level attempt counts as a string-keyed dictionary
-    /// suitable for JSON serialisation and storage on <c>DelayedRetry</c> / <c>Xchange</c>.
-    /// </summary>
-    public Dictionary<string, int> GetGroupAttemptCounts() =>
-        _groupAttemptCounts.ToDictionary(kv => kv.Key.ToString(), kv => kv.Value);
-
     /// <summary>
     /// Evaluates the policy and returns a retry decision for the failed xchange.
     /// </summary>
@@ -69,7 +40,7 @@ public class RetryPolicyEvaluator(IRetryPolicy policy)
     /// <returns>
     /// A <see cref="RetryDecision"/> indicating whether to retry and, if so, how long to wait.
     /// </returns>
-    public RetryDecision Evaluate(
+    public async Task<RetryDecision> Evaluate(
         XchangeResultType resultType,
         string content,
         int attemptIndexForThisMessage)
@@ -91,12 +62,11 @@ public class RetryPolicyEvaluator(IRetryPolicy policy)
             return RetryDecision.Block(
                 $"Per-message cap reached ({budget.MaxAttemptsPerError}) in group '{group.Name}'");
 
-        var totalUsed = _groupAttemptCounts.GetValueOrDefault(group.Id, 0);
-        if (totalUsed >= budget.MaxAttemptsTotal)
+        // Claimed last so a message already stopped by its own per-message cap doesn't
+        // eat a slot out of the shared total.
+        if (!await groupBudget.TryConsume(group.Id, budget.MaxAttemptsTotal))
             return RetryDecision.Block(
                 $"Group total cap reached ({budget.MaxAttemptsTotal}) for group '{group.Name}'");
-
-        _groupAttemptCounts[group.Id] = totalUsed + 1;
 
         var delay = budget.DelayStrategy.GetDelay(attemptIndexForThisMessage);
         return RetryDecision.Allow(delay, group.Name);

--- a/SW.Bitween.Sdk/Model/RetryPolicyModel.cs
+++ b/SW.Bitween.Sdk/Model/RetryPolicyModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace SW.Bitween.Model;
@@ -15,6 +16,43 @@ public class RetryPolicyRow
     public int Id { get; set; }
     public string Name { get; set; }
     public int GroupCount { get; set; }
+}
+
+/// <summary>
+/// How much of a group's <see cref="RetryBudget.MaxAttemptsTotal"/> one integration has spent.
+/// The total is tracked per integration, so a policy shared by several yields one row each.
+/// </summary>
+public class RetryGroupUsageRow
+{
+    public int SubscriptionId { get; set; }
+    public string SubscriptionName { get; set; }
+    public Guid GroupId { get; set; }
+
+    /// <summary>Null when the group has since been renamed away or removed from the policy.</summary>
+    public string GroupName { get; set; }
+
+    public int AttemptsUsed { get; set; }
+    public int MaxAttemptsTotal { get; set; }
+
+    /// <summary>True when the budget is spent and this integration will get no further retries.</summary>
+    public bool Exhausted { get; set; }
+
+    public DateTime LastAttemptOn { get; set; }
+}
+
+/// <summary>Empty request body — the policy is identified by the route key.</summary>
+public class RetryPolicyUsageRequest
+{
+}
+
+/// <summary>
+/// Clears spent budget so a group starts retrying again. Omit both fields to reset every
+/// integration and group of the policy.
+/// </summary>
+public class RetryPolicyResetUsage
+{
+    public int? SubscriptionId { get; set; }
+    public Guid? GroupId { get; set; }
 }
 
 /// <summary>

--- a/SW.Bitween.Sdk/Model/Xchange.cs
+++ b/SW.Bitween.Sdk/Model/Xchange.cs
@@ -97,5 +97,8 @@ namespace SW.Bitween.Model
         public string CorrelationId { get; set; }
         public int? PartnerId { get; set; }
         public DateTime? ScheduledRetryOn { get; set; }
+
+        /// <summary>Why the retry policy declined to schedule another attempt, when it declined.</summary>
+        public string RetryBlockedReason { get; set; }
     }
 }

--- a/SW.Bitween.UnitTests/RetryPolicyEvaluatorTests.cs
+++ b/SW.Bitween.UnitTests/RetryPolicyEvaluatorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SW.Bitween.Model;
 
@@ -56,6 +57,11 @@ public class RetryPolicyEvaluatorTests
                 DelayStrategy = delay ?? new FixedDelayStrategy { DelayMs = 1000 }
             }
         };
+
+    // Each call gets its own budget, so tests that don't care about the shared total
+    // stay isolated from each other.
+    private static RetryPolicyEvaluator Evaluator(IRetryPolicy policy) =>
+        new RetryPolicyEvaluator(policy, new InMemoryRetryGroupBudget());
 
     private sealed class TestPolicy(RetryGroup[] groups) : IRetryPolicy
     {
@@ -218,124 +224,124 @@ public class RetryPolicyEvaluatorTests
     // ─── Evaluator: basic routing ────────────────────────────────────────────────
 
     [TestMethod]
-    public void Evaluator_MatchingGroup_AllowsRetry()
+    public async Task Evaluator_MatchingGroup_AllowsRetry()
     {
         var policy = PolicyWith(ErrorGroup("transient", new ContainsMatcher { Value = "timeout" }));
-        var ev = new RetryPolicyEvaluator(policy);
-        var decision = ev.Evaluate(XchangeResultType.Error, "Connection timeout", 0);
+        var ev = Evaluator(policy);
+        var decision = await ev.Evaluate(XchangeResultType.Error, "Connection timeout", 0);
         Assert.IsTrue(decision.ShouldRetry);
         Assert.AreEqual("transient", decision.MatchedGroupName);
     }
 
     [TestMethod]
-    public void Evaluator_NoMatchingGroup_Blocks()
+    public async Task Evaluator_NoMatchingGroup_Blocks()
     {
         var policy = PolicyWith(ErrorGroup("transient", new ContainsMatcher { Value = "timeout" }));
-        var ev = new RetryPolicyEvaluator(policy);
-        var decision = ev.Evaluate(XchangeResultType.Error, "Disk full", 0);
+        var ev = Evaluator(policy);
+        var decision = await ev.Evaluate(XchangeResultType.Error, "Disk full", 0);
         Assert.IsFalse(decision.ShouldRetry);
     }
 
     [TestMethod]
-    public void Evaluator_WrongResultType_GroupSkipped()
+    public async Task Evaluator_WrongResultType_GroupSkipped()
     {
         var policy = PolicyWith(BadResultGroup("bad", new JsonPathMatcher { Path = "$.retryable", Op = JsonPathOp.Exists }));
-        var ev = new RetryPolicyEvaluator(policy);
+        var ev = Evaluator(policy);
         // Group is for BadResult only — must be skipped for Error
-        var decision = ev.Evaluate(XchangeResultType.Error, "some exception", 0);
+        var decision = await ev.Evaluate(XchangeResultType.Error, "some exception", 0);
         Assert.IsFalse(decision.ShouldRetry);
     }
 
     [TestMethod]
-    public void Evaluator_ContainsMatcher_MatchesBadResultBody()
+    public async Task Evaluator_ContainsMatcher_MatchesBadResultBody()
     {
         var policy = PolicyWith(BadResultGroup("bad", new ContainsMatcher { Value = "INSUFFICIENT_STOCK" }));
-        var ev = new RetryPolicyEvaluator(policy);
-        var decision = ev.Evaluate(XchangeResultType.BadResult, "{\"code\":\"INSUFFICIENT_STOCK\"}", 0);
+        var ev = Evaluator(policy);
+        var decision = await ev.Evaluate(XchangeResultType.BadResult, "{\"code\":\"INSUFFICIENT_STOCK\"}", 0);
         Assert.IsTrue(decision.ShouldRetry);
         Assert.AreEqual("bad", decision.MatchedGroupName);
     }
 
     [TestMethod]
-    public void Evaluator_ContainsMatcher_MatchesNonJsonBadResultBody()
+    public async Task Evaluator_ContainsMatcher_MatchesNonJsonBadResultBody()
     {
         // A 4xx body need not be JSON — text matchers are the only way to reach these.
         var policy = PolicyWith(BadResultGroup("bad", new ContainsMatcher { Value = "rate limit" }));
-        var ev = new RetryPolicyEvaluator(policy);
-        var decision = ev.Evaluate(XchangeResultType.BadResult, "<html><body>Rate limit exceeded</body></html>", 0);
+        var ev = Evaluator(policy);
+        var decision = await ev.Evaluate(XchangeResultType.BadResult, "<html><body>Rate limit exceeded</body></html>", 0);
         Assert.IsTrue(decision.ShouldRetry);
     }
 
     [TestMethod]
-    public void Evaluator_RegexMatcher_MatchesBadResultBody()
+    public async Task Evaluator_RegexMatcher_MatchesBadResultBody()
     {
         var policy = PolicyWith(BadResultGroup("bad", new RegexMatcher { Pattern = @"""status"":\s*""FAILED""" }));
-        var ev = new RetryPolicyEvaluator(policy);
-        var decision = ev.Evaluate(XchangeResultType.BadResult, "{\"status\": \"FAILED\"}", 0);
+        var ev = Evaluator(policy);
+        var decision = await ev.Evaluate(XchangeResultType.BadResult, "{\"status\": \"FAILED\"}", 0);
         Assert.IsTrue(decision.ShouldRetry);
     }
 
     [TestMethod]
-    public void Evaluator_ExceptionTypeMatcher_SkippedForBadResult()
+    public async Task Evaluator_ExceptionTypeMatcher_SkippedForBadResult()
     {
         // Exception type names are meaningless against a response body — stays Error-only.
         var policy = PolicyWith(BadResultGroup("bad", new ExceptionTypeMatcher { Value = "System.TimeoutException" }));
-        var ev = new RetryPolicyEvaluator(policy);
-        var decision = ev.Evaluate(XchangeResultType.BadResult, "System.TimeoutException in body", 0);
+        var ev = Evaluator(policy);
+        var decision = await ev.Evaluate(XchangeResultType.BadResult, "System.TimeoutException in body", 0);
         Assert.IsFalse(decision.ShouldRetry);
     }
 
     // ─── Evaluator: priority ordering ───────────────────────────────────────────
 
     [TestMethod]
-    public void Evaluator_LowerPriorityEvaluatedFirst()
+    public async Task Evaluator_LowerPriorityEvaluatedFirst()
     {
         var g1 = ErrorGroup("low-num", new ContainsMatcher { Value = "error" }, priority: 1);
         var g2 = ErrorGroup("high-num", new ContainsMatcher { Value = "error" }, priority: 20);
         var policy = PolicyWith(g2, g1); // intentionally reversed in array
-        var ev = new RetryPolicyEvaluator(policy);
-        var decision = ev.Evaluate(XchangeResultType.Error, "error occurred", 0);
+        var ev = Evaluator(policy);
+        var decision = await ev.Evaluate(XchangeResultType.Error, "error occurred", 0);
         Assert.AreEqual("low-num", decision.MatchedGroupName);
     }
 
     [TestMethod]
-    public void Evaluator_OnlyMatchingGroupFires()
+    public async Task Evaluator_OnlyMatchingGroupFires()
     {
         var g1 = ErrorGroup("timeouts", new ContainsMatcher { Value = "timeout" }, priority: 1);
         var g2 = ErrorGroup("disk", new ContainsMatcher { Value = "disk" }, priority: 20);
         var policy = PolicyWith(g1, g2);
-        var ev = new RetryPolicyEvaluator(policy);
-        var decision = ev.Evaluate(XchangeResultType.Error, "disk full", 0);
+        var ev = Evaluator(policy);
+        var decision = await ev.Evaluate(XchangeResultType.Error, "disk full", 0);
         Assert.AreEqual("disk", decision.MatchedGroupName);
     }
 
     // ─── Evaluator: budget — MaxAttemptsPerError ─────────────────────────────────
 
     [TestMethod]
-    public void Evaluator_MaxAttemptsPerError_BlocksAfterCap()
+    public async Task Evaluator_MaxAttemptsPerError_BlocksAfterCap()
     {
         var policy = PolicyWith(ErrorGroup("transient", new ContainsMatcher { Value = "err" }, maxPerError: 2));
-        var ev = new RetryPolicyEvaluator(policy);
+        var ev = Evaluator(policy);
 
-        Assert.IsTrue(ev.Evaluate(XchangeResultType.Error, "err", 0).ShouldRetry);
-        Assert.IsTrue(ev.Evaluate(XchangeResultType.Error, "err", 1).ShouldRetry);
-        Assert.IsFalse(ev.Evaluate(XchangeResultType.Error, "err", 2).ShouldRetry); // cap = 2
+        Assert.IsTrue((await ev.Evaluate(XchangeResultType.Error, "err", 0)).ShouldRetry);
+        Assert.IsTrue((await ev.Evaluate(XchangeResultType.Error, "err", 1)).ShouldRetry);
+        Assert.IsFalse((await ev.Evaluate(XchangeResultType.Error, "err", 2)).ShouldRetry); // cap = 2
     }
 
     // ─── Evaluator: budget — MaxAttemptsTotal ────────────────────────────────────
 
     [TestMethod]
-    public void Evaluator_MaxAttemptsTotal_BlocksAfterGroupCap()
+    public async Task Evaluator_MaxAttemptsTotal_BlocksAfterGroupCap()
     {
         var policy = PolicyWith(ErrorGroup("transient", new ContainsMatcher { Value = "err" },
             maxPerError: 100, maxTotal: 3));
-        var ev = new RetryPolicyEvaluator(policy);
+        var ev = Evaluator(policy);
 
         // Three different "messages" (attempt index 0 each time) exhaust the group total
-        Assert.IsTrue(ev.Evaluate(XchangeResultType.Error, "err", 0).ShouldRetry);
-        Assert.IsTrue(ev.Evaluate(XchangeResultType.Error, "err", 0).ShouldRetry);
-        Assert.IsTrue(ev.Evaluate(XchangeResultType.Error, "err", 0).ShouldRetry);
-        Assert.IsFalse(ev.Evaluate(XchangeResultType.Error, "err", 0).ShouldRetry); // exceeded total=3
+        Assert.IsTrue((await ev.Evaluate(XchangeResultType.Error, "err", 0)).ShouldRetry);
+        Assert.IsTrue((await ev.Evaluate(XchangeResultType.Error, "err", 0)).ShouldRetry);
+        Assert.IsTrue((await ev.Evaluate(XchangeResultType.Error, "err", 0)).ShouldRetry);
+        Assert.IsFalse((await ev.Evaluate(XchangeResultType.Error, "err", 0)).ShouldRetry); // exceeded total=3
     }
 
     // ─── Evaluator: delay strategies ─────────────────────────────────────────────
@@ -369,67 +375,74 @@ public class RetryPolicyEvaluatorTests
     }
 
     [TestMethod]
-    public void Evaluator_DelayFromStrategy_ReturnsCorrectValue()
+    public async Task Evaluator_DelayFromStrategy_ReturnsCorrectValue()
     {
         var policy = PolicyWith(ErrorGroup("transient",
             new ContainsMatcher { Value = "err" },
             delay: new FixedDelayStrategy { DelayMs = 3000 }));
-        var ev = new RetryPolicyEvaluator(policy);
-        var decision = ev.Evaluate(XchangeResultType.Error, "err", 0);
+        var ev = Evaluator(policy);
+        var decision = await ev.Evaluate(XchangeResultType.Error, "err", 0);
         Assert.AreEqual(TimeSpan.FromMilliseconds(3000), decision.Delay);
     }
 
-    // ─── Evaluator: GroupAttemptCounts persistence ───────────────────────────────
+    // ─── Evaluator: the total cap is shared, not per message ─────────────────────
 
     [TestMethod]
-    public void GroupAttemptCounts_RestoredAcrossEvaluators_ContinuesBudget()
+    public async Task Evaluator_MaxAttemptsTotal_SharedAcrossSeparateMessages()
     {
+        // The bug this covers: one evaluator per failed xchange, each starting from zero, so
+        // four failing messages × 3 per-message attempts produced 12 retries under a total of 10.
         var policy = PolicyWith(ErrorGroup("transient", new ContainsMatcher { Value = "err" },
-            maxPerError: 100, maxTotal: 2));
+            maxPerError: 3, maxTotal: 4));
+        var budget = new InMemoryRetryGroupBudget();
 
-        var ev1 = new RetryPolicyEvaluator(policy);
-        Assert.IsTrue(ev1.Evaluate(XchangeResultType.Error, "err", 0).ShouldRetry); // group count = 1
-        var counts = ev1.GetGroupAttemptCounts();
+        var allowed = 0;
+        for (var message = 0; message < 4; message++)
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            // A fresh evaluator per failure, exactly as XchangeService builds one.
+            var ev = new RetryPolicyEvaluator(policy, budget);
+            if ((await ev.Evaluate(XchangeResultType.Error, "err", attempt)).ShouldRetry) allowed++;
+        }
 
-        // Simulate the next evaluator instance restoring saved state
-        var ev2 = new RetryPolicyEvaluator(policy);
-        ev2.RestoreGroupAttemptCounts(counts); // group count restored to 1
-        Assert.IsTrue(ev2.Evaluate(XchangeResultType.Error, "err", 0).ShouldRetry); // group count = 2
-        var counts2 = ev2.GetGroupAttemptCounts();
-
-        var ev3 = new RetryPolicyEvaluator(policy);
-        ev3.RestoreGroupAttemptCounts(counts2); // group count restored to 2
-        Assert.IsFalse(ev3.Evaluate(XchangeResultType.Error, "err", 0).ShouldRetry); // exceeded total=2
+        Assert.AreEqual(4, allowed);
     }
 
     [TestMethod]
-    public void GroupAttemptCounts_WithoutRestore_BudgetResetsToZero()
+    public async Task Evaluator_MaxAttemptsTotal_SeparateBudgetsDoNotShare()
     {
+        // Two integrations pointed at the same policy template get independent totals.
         var policy = PolicyWith(ErrorGroup("transient", new ContainsMatcher { Value = "err" },
             maxPerError: 100, maxTotal: 1));
 
-        var ev1 = new RetryPolicyEvaluator(policy);
-        Assert.IsTrue(ev1.Evaluate(XchangeResultType.Error, "err", 0).ShouldRetry); // exhausted
-
-        // Fresh evaluator without restore — budget starts from 0 again
-        var ev2 = new RetryPolicyEvaluator(policy);
-        Assert.IsTrue(ev2.Evaluate(XchangeResultType.Error, "err", 0).ShouldRetry);
+        Assert.IsTrue((await Evaluator(policy).Evaluate(XchangeResultType.Error, "err", 0)).ShouldRetry);
+        Assert.IsTrue((await Evaluator(policy).Evaluate(XchangeResultType.Error, "err", 0)).ShouldRetry);
     }
 
     [TestMethod]
-    public void GetGroupAttemptCounts_ReturnsNonEmptyAfterMatch()
+    public async Task Evaluator_PerMessageCapBlocked_DoesNotSpendSharedTotal()
     {
-        var policy = PolicyWith(ErrorGroup("transient", new ContainsMatcher { Value = "err" }));
-        var ev = new RetryPolicyEvaluator(policy);
-        ev.Evaluate(XchangeResultType.Error, "err", 0);
-        var counts = ev.GetGroupAttemptCounts();
-        Assert.IsTrue(counts.Count > 0);
+        var policy = PolicyWith(ErrorGroup("transient", new ContainsMatcher { Value = "err" },
+            maxPerError: 1, maxTotal: 2));
+        var budget = new InMemoryRetryGroupBudget();
+
+        // Attempt index 1 is past the per-message cap, so it must not claim a slot.
+        Assert.IsFalse((await new RetryPolicyEvaluator(policy, budget)
+            .Evaluate(XchangeResultType.Error, "err", 1)).ShouldRetry);
+
+        // Both slots of the total are therefore still there.
+        Assert.IsTrue((await new RetryPolicyEvaluator(policy, budget)
+            .Evaluate(XchangeResultType.Error, "err", 0)).ShouldRetry);
+        Assert.IsTrue((await new RetryPolicyEvaluator(policy, budget)
+            .Evaluate(XchangeResultType.Error, "err", 0)).ShouldRetry);
+        Assert.IsFalse((await new RetryPolicyEvaluator(policy, budget)
+            .Evaluate(XchangeResultType.Error, "err", 0)).ShouldRetry);
     }
 
     // ─── Evaluator: Block action ─────────────────────────────────────────────────
 
     [TestMethod]
-    public void Evaluator_BlockAction_NeverRetries()
+    public async Task Evaluator_BlockAction_NeverRetries()
     {
         var blockGroup = new RetryGroup
         {
@@ -442,8 +455,8 @@ public class RetryPolicyEvaluatorTests
             Budget = null
         };
         var policy = PolicyWith(blockGroup);
-        var ev = new RetryPolicyEvaluator(policy);
-        var decision = ev.Evaluate(XchangeResultType.Error, "fatal: cannot recover", 0);
+        var ev = Evaluator(policy);
+        var decision = await ev.Evaluate(XchangeResultType.Error, "fatal: cannot recover", 0);
         Assert.IsFalse(decision.ShouldRetry);
     }
 }


### PR DESCRIPTION
The group total was tracked in a dictionary carried on each xchange, so every failing message started from zero and got its own full budget: 4 messages under a total of 10 produced 12 retries. It also always equalled the per-message attempt count, so the cap could never fire above MaxAttemptsPerError.

The total now lives in a RetryGroupUsage table keyed by integration + group, and the evaluator claims from it via IRetryGroupBudget. Dry-runs use an in-memory implementation so simulating never spends a real budget. GroupAttemptCounts is dropped from Xchange and DelayedRetry.

The total never resets on its own, so /usage reports what each integration has spent and /resetusage clears it. XchangeResult now records why a retry was refused, since a group with an exhausted budget was previously indistinguishable from one that never matched.